### PR TITLE
Skip asset CDN transform override for Craft action requests

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -100,7 +100,7 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 Asset::class,
                 Asset::EVENT_BEFORE_GENERATE_TRANSFORM,
                 function(GenerateTransformEvent $event) {
-                    if (!$event->transform || !$event->asset?->fs instanceof AssetsFs) {
+                    if (!$this->shouldOverrideTransformUrl($event)) {
                         return;
                     }
 
@@ -212,6 +212,15 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 $e->rules = $this->removeAttributeFromRules($e->rules, 'tempFilePath');
             }
         );
+    }
+
+    protected function shouldOverrideTransformUrl(GenerateTransformEvent $event): bool
+    {
+        if (!$event->transform || !$event->asset?->fs instanceof AssetsFs) {
+            return false;
+        }
+
+        return !Craft::$app->getRequest()->getIsActionRequest();
     }
 
     protected function validateConfig(): void


### PR DESCRIPTION
## Summary
- skip the Cloud asset CDN transform URL override for Craft action requests
- likely regressed with this change: https://github.com/craftcms/cloud/commit/632caad1521a93b3363659baee06e1805239aa6a

## Issue
- Fixes https://github.com/craftcms/cloud/issues/149