### PR TITLE
[3.x] Bound Cloud upload metadata

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -11,8 +11,6 @@ use craft\events\ReplaceAssetEvent;
 use craft\fields\Assets as AssetsField;
 use craft\helpers\Assets;
 use craft\helpers\Db;
-use craft\helpers\FileHelper;
-use craft\helpers\Image;
 use craft\models\Volume;
 use craft\web\Controller;
 use DateTime;
@@ -27,6 +25,8 @@ use yii\web\Response;
 class AssetsController extends Controller
 {
     use AssetsControllerTrait;
+
+    private const IMAGE_DIMENSION_HEADER_BYTES = 1048576;
 
     public function actionGetUploadUrl(): Response
     {
@@ -97,7 +97,6 @@ class AssetsController extends Controller
         $filename = $this->request->getRequiredBodyParam('filename');
         $originalFilename = $this->request->getRequiredBodyParam('originalFilename');
         $targetFilename = $this->request->getRequiredBodyParam('targetFilename');
-        $size = $this->request->getBodyParam('size');
         $elementsService = Craft::$app->getElements();
         $lastModifiedMs = (int) $this->request->getBodyParam('lastModified');
         $dateModified = $lastModifiedMs
@@ -160,7 +159,6 @@ class AssetsController extends Controller
         $asset->uploaderId = Craft::$app->getUser()->getId();
         $asset->avoidFilenameConflicts = true;
         $asset->dateModified = $dateModified;
-        $asset->size = $size;
 
         // Setting newFolderId, so that extension validation on newLocation occurs
         $asset->newFolderId = $folder->id;
@@ -171,6 +169,7 @@ class AssetsController extends Controller
         // Handle special characters that have been encoded from the presigned URL
         $asset->folderPath = is_string($folder->path) ? Fs::urlEncodePathSegments($folder->path) : $asset->folderPath;
 
+        $asset->size = $this->uploadedAssetSize($asset, $filename);
         [$asset->width, $asset->height] = $this->uploadedImageDimensions($asset, $filename);
 
         if (!$selectionCondition) {
@@ -240,7 +239,6 @@ class AssetsController extends Controller
         $sourceAssetId = $this->request->getBodyParam('sourceAssetId');
         $filename = $this->request->getBodyParam('filename');
         $targetFilename = $this->request->getBodyParam('targetFilename');
-        $size = $this->request->getBodyParam('size');
         $lastModifiedMs = (int) $this->request->getBodyParam('lastModified');
         $dateModified = $lastModifiedMs
             ? DateTime::createFromFormat('U', (string) floor($lastModifiedMs / 1000))
@@ -271,7 +269,7 @@ class AssetsController extends Controller
 
         // Handle the Element Action
         if ($assetToReplace !== null && $filename) {
-            $assetToReplace->size = $size;
+            $assetToReplace->size = $this->uploadedAssetSize($assetToReplace, $filename);
             $assetToReplace->dateModified = $dateModified;
             if (!$this->replaceAssetFile($assetToReplace, $filename, $targetFilename)) {
                 throw new Exception('Unable to replace asset.');
@@ -395,6 +393,19 @@ class AssetsController extends Controller
         return method_exists($volume, 'getSubpath') ? $volume->getSubpath() : '';
     }
 
+    protected function uploadedAssetSize(Asset $asset, string $filename): int
+    {
+        $size = $asset->getVolume()->getFileSize($asset->getPath($filename));
+
+        if ($size > Assets::getMaxUploadSize()) {
+            throw new BadRequestHttpException(Craft::t('app', '“{filename}” is too large.', [
+                'filename' => $filename,
+            ]));
+        }
+
+        return $size;
+    }
+
     protected function uploadedImageDimensions(Asset $asset, string $filename): array
     {
         if (Assets::getFileKindByExtension($filename) !== Asset::KIND_IMAGE) {
@@ -407,34 +418,123 @@ class AssetsController extends Controller
     protected function readUploadedImageDimensions(Asset $asset): ?array
     {
         $stream = null;
-        $tempPath = null;
 
         try {
             $stream = $asset->getVolume()->getFs()->getFileStream($asset->getPath());
-            $imageSize = Image::imageSizeByStream($stream);
+            $imageSize = $this->imageDimensionsFromHeader(
+                stream_get_contents($stream, self::IMAGE_DIMENSION_HEADER_BYTES),
+            );
 
-            if ($imageSize === false || !isset($imageSize[0], $imageSize[1])) {
-                fclose($stream);
-                $stream = null;
-
-                $tempPath = $asset->getCopyOfFile();
-                $imageSize = Image::imageSize($tempPath);
+            if ($imageSize === null) {
+                return null;
             }
 
-            return [
-                (int)$imageSize[0] ?: null,
-                (int)$imageSize[1] ?: null,
-            ];
+            return $imageSize;
         } catch (Throwable) {
             return null;
         } finally {
             if (is_resource($stream)) {
                 fclose($stream);
             }
-
-            if ($tempPath !== null) {
-                FileHelper::unlink($tempPath);
-            }
         }
+    }
+
+    protected function imageDimensionsFromHeader(string|false $data): ?array
+    {
+        if (!is_string($data) || strlen($data) < 10) {
+            return null;
+        }
+
+        return match (substr($data, 0, 2)) {
+            "\xFF\xD8" => $this->jpegDimensionsFromHeader($data),
+            'GI' => $this->gifDimensionsFromHeader($data),
+            "\x89P" => $this->pngDimensionsFromHeader($data),
+            default => null,
+        };
+    }
+
+    private function gifDimensionsFromHeader(string $data): ?array
+    {
+        if (!in_array(substr($data, 0, 6), ['GIF89a', 'GIF87a'], true)) {
+            return null;
+        }
+
+        $dimensions = unpack('vwidth/vheight', substr($data, 6, 4));
+
+        return isset($dimensions['width'], $dimensions['height'])
+            ? [(int)$dimensions['width'] ?: null, (int)$dimensions['height'] ?: null]
+            : null;
+    }
+
+    private function pngDimensionsFromHeader(string $data): ?array
+    {
+        if (strlen($data) < 24 || substr($data, 0, 8) !== "\x89PNG\x0D\x0A\x1A\x0A" || substr($data, 12, 4) !== 'IHDR') {
+            return null;
+        }
+
+        $dimensions = unpack('Nwidth/Nheight', substr($data, 16, 8));
+
+        return isset($dimensions['width'], $dimensions['height'])
+            ? [(int)$dimensions['width'] ?: null, (int)$dimensions['height'] ?: null]
+            : null;
+    }
+
+    private function jpegDimensionsFromHeader(string $data): ?array
+    {
+        $validFrames = [0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF];
+        $offset = 2;
+        $length = strlen($data);
+
+        while ($offset + 4 <= $length) {
+            if (ord($data[$offset]) !== 0xFF) {
+                return null;
+            }
+
+            while ($offset < $length && ord($data[$offset]) === 0xFF) {
+                $offset++;
+            }
+
+            if ($offset >= $length) {
+                return null;
+            }
+
+            $marker = ord($data[$offset]);
+            $offset++;
+
+            if ($marker === 0xD9 || $marker === 0xDA) {
+                return null;
+            }
+
+            if ($marker === 0x01 || ($marker >= 0xD0 && $marker <= 0xD7)) {
+                continue;
+            }
+
+            if ($offset + 2 > $length) {
+                return null;
+            }
+
+            $segment = unpack('nlength', substr($data, $offset, 2));
+            $segmentLength = $segment['length'] ?? 0;
+
+            if ($segmentLength < 2 || $offset + $segmentLength > $length) {
+                return null;
+            }
+
+            if (in_array($marker, $validFrames, true)) {
+                if ($segmentLength < 7) {
+                    return null;
+                }
+
+                $dimensions = unpack('nheight/nwidth', substr($data, $offset + 3, 4));
+
+                return isset($dimensions['width'], $dimensions['height'])
+                    ? [(int)$dimensions['width'] ?: null, (int)$dimensions['height'] ?: null]
+                    : null;
+            }
+
+            $offset += $segmentLength;
+        }
+
+        return null;
     }
 }

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -11,6 +11,7 @@ use craft\events\ReplaceAssetEvent;
 use craft\fields\Assets as AssetsField;
 use craft\helpers\Assets;
 use craft\helpers\Db;
+use craft\helpers\Image;
 use craft\models\Volume;
 use craft\web\Controller;
 use DateTime;
@@ -417,18 +418,38 @@ class AssetsController extends Controller
 
     protected function readUploadedImageDimensions(Asset $asset): ?array
     {
-        $header = $this->uploadedImageHeader($asset);
+        $stream = $this->uploadedImageHeaderStream($asset);
 
-        if ($header === null) {
+        if ($stream === null) {
             return null;
         }
 
-        return $this->imageDimensionsFromHeader($header);
+        try {
+            $imageSize = Image::imageSizeByStream($stream);
+
+            if ($imageSize === false || !isset($imageSize[0], $imageSize[1])) {
+                return null;
+            }
+
+            return [
+                (int)$imageSize[0] ?: null,
+                (int)$imageSize[1] ?: null,
+            ];
+        } catch (Throwable) {
+            return null;
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
     }
 
-    protected function uploadedImageHeader(Asset $asset): ?string
+    /**
+     * @return resource|null
+     */
+    protected function uploadedImageHeaderStream(Asset $asset)
     {
-        $stream = null;
+        $sourceStream = null;
 
         try {
             $fs = $asset->getVolume()->getFs();
@@ -446,118 +467,36 @@ class AssetsController extends Controller
                     'Range' => sprintf('bytes=0-%d', self::IMAGE_DIMENSION_HEADER_BYTES - 1),
                 ]);
 
-                return (string)$object->get('Body');
+                return $this->stringStream((string)$object->get('Body'));
             }
 
-            $stream = $fs->getFileStream($asset->getPath());
-            $data = stream_get_contents($stream, self::IMAGE_DIMENSION_HEADER_BYTES);
+            $sourceStream = $fs->getFileStream($asset->getPath());
+            $data = stream_get_contents($sourceStream, self::IMAGE_DIMENSION_HEADER_BYTES);
 
-            return is_string($data) ? $data : null;
+            return is_string($data) ? $this->stringStream($data) : null;
         } catch (Throwable) {
             return null;
         } finally {
-            if (is_resource($stream)) {
-                fclose($stream);
+            if (is_resource($sourceStream)) {
+                fclose($sourceStream);
             }
         }
     }
 
-    protected function imageDimensionsFromHeader(string|false $data): ?array
+    /**
+     * @return resource|null
+     */
+    private function stringStream(string $contents)
     {
-        if (!is_string($data) || strlen($data) < 10) {
+        $stream = fopen('php://temp', 'r+');
+
+        if ($stream === false) {
             return null;
         }
 
-        return match (substr($data, 0, 2)) {
-            "\xFF\xD8" => $this->jpegDimensionsFromHeader($data),
-            'GI' => $this->gifDimensionsFromHeader($data),
-            "\x89P" => $this->pngDimensionsFromHeader($data),
-            default => null,
-        };
-    }
+        fwrite($stream, $contents);
+        rewind($stream);
 
-    private function gifDimensionsFromHeader(string $data): ?array
-    {
-        if (!in_array(substr($data, 0, 6), ['GIF89a', 'GIF87a'], true)) {
-            return null;
-        }
-
-        $dimensions = unpack('vwidth/vheight', substr($data, 6, 4));
-
-        return isset($dimensions['width'], $dimensions['height'])
-            ? [(int)$dimensions['width'] ?: null, (int)$dimensions['height'] ?: null]
-            : null;
-    }
-
-    private function pngDimensionsFromHeader(string $data): ?array
-    {
-        if (strlen($data) < 24 || substr($data, 0, 8) !== "\x89PNG\x0D\x0A\x1A\x0A" || substr($data, 12, 4) !== 'IHDR') {
-            return null;
-        }
-
-        $dimensions = unpack('Nwidth/Nheight', substr($data, 16, 8));
-
-        return isset($dimensions['width'], $dimensions['height'])
-            ? [(int)$dimensions['width'] ?: null, (int)$dimensions['height'] ?: null]
-            : null;
-    }
-
-    private function jpegDimensionsFromHeader(string $data): ?array
-    {
-        $validFrames = [0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF];
-        $offset = 2;
-        $length = strlen($data);
-
-        while ($offset + 4 <= $length) {
-            if (ord($data[$offset]) !== 0xFF) {
-                return null;
-            }
-
-            while ($offset < $length && ord($data[$offset]) === 0xFF) {
-                $offset++;
-            }
-
-            if ($offset >= $length) {
-                return null;
-            }
-
-            $marker = ord($data[$offset]);
-            $offset++;
-
-            if ($marker === 0xD9 || $marker === 0xDA) {
-                return null;
-            }
-
-            if ($marker === 0x01 || ($marker >= 0xD0 && $marker <= 0xD7)) {
-                continue;
-            }
-
-            if ($offset + 2 > $length) {
-                return null;
-            }
-
-            $segment = unpack('nlength', substr($data, $offset, 2));
-            $segmentLength = $segment['length'] ?? 0;
-
-            if ($segmentLength < 2 || $offset + $segmentLength > $length) {
-                return null;
-            }
-
-            if (in_array($marker, $validFrames, true)) {
-                if ($segmentLength < 7) {
-                    return null;
-                }
-
-                $dimensions = unpack('nheight/nwidth', substr($data, $offset + 3, 4));
-
-                return isset($dimensions['width'], $dimensions['height'])
-                    ? [(int)$dimensions['width'] ?: null, (int)$dimensions['height'] ?: null]
-                    : null;
-            }
-
-            $offset += $segmentLength;
-        }
-
-        return null;
+        return $stream;
     }
 }

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -167,7 +167,10 @@ class AssetsController extends Controller
         $asset->folderPath = is_string($folder->path) ? Fs::urlEncodePathSegments($folder->path) : $asset->folderPath;
 
         $asset->size = $this->uploadedAssetSize($asset, $filename);
-        [$asset->width, $asset->height] = $this->uploadedImageDimensions($asset);
+        $fs = $asset->getVolume()->getFs();
+        [$asset->width, $asset->height] = $fs instanceof Fs
+            ? $fs->getImageDimensions($asset->getPath()) ?? [null, null]
+            : [null, null];
 
         if (!$selectionCondition) {
             $asset->newFilename = $targetFilename;
@@ -349,7 +352,10 @@ class AssetsController extends Controller
         $asset->avoidFilenameConflicts = true;
         $asset->setScenario(Asset::SCENARIO_REPLACE);
         $asset->setFilename($filename);
-        [$asset->width, $asset->height] = $this->uploadedImageDimensions($asset);
+        $fs = $asset->getVolume()->getFs();
+        [$asset->width, $asset->height] = $fs instanceof Fs
+            ? $fs->getImageDimensions($asset->getPath()) ?? [null, null]
+            : [null, null];
         $asset->newFilename = $targetFilename;
 
         $saved = $this->saveAsset($asset);
@@ -401,21 +407,5 @@ class AssetsController extends Controller
         }
 
         return $size;
-    }
-
-    protected function uploadedImageDimensions(Asset $asset): array
-    {
-        return $this->readUploadedImageDimensions($asset) ?? [null, null];
-    }
-
-    protected function readUploadedImageDimensions(Asset $asset): ?array
-    {
-        $fs = $asset->getVolume()->getFs();
-
-        if (!$fs instanceof Fs) {
-            return null;
-        }
-
-        return $fs->getImageDimensions($asset->getPath());
     }
 }

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -417,19 +417,42 @@ class AssetsController extends Controller
 
     protected function readUploadedImageDimensions(Asset $asset): ?array
     {
+        $header = $this->uploadedImageHeader($asset);
+
+        if ($header === null) {
+            return null;
+        }
+
+        return $this->imageDimensionsFromHeader($header);
+    }
+
+    protected function uploadedImageHeader(Asset $asset): ?string
+    {
         $stream = null;
 
         try {
-            $stream = $asset->getVolume()->getFs()->getFileStream($asset->getPath());
-            $imageSize = $this->imageDimensionsFromHeader(
-                stream_get_contents($stream, self::IMAGE_DIMENSION_HEADER_BYTES),
-            );
+            $fs = $asset->getVolume()->getFs();
 
-            if ($imageSize === null) {
-                return null;
+            if ($fs instanceof Fs && !$fs->useLocalFs) {
+                $bucket = $fs->getBucketName();
+
+                if ($bucket === null) {
+                    return null;
+                }
+
+                $object = $fs->getClient()->getObject([
+                    'Bucket' => $bucket,
+                    'Key' => $fs->createBucketPath($asset->getPath())->toString(),
+                    'Range' => sprintf('bytes=0-%d', self::IMAGE_DIMENSION_HEADER_BYTES - 1),
+                ]);
+
+                return (string)$object->get('Body');
             }
 
-            return $imageSize;
+            $stream = $fs->getFileStream($asset->getPath());
+            $data = stream_get_contents($stream, self::IMAGE_DIMENSION_HEADER_BYTES);
+
+            return is_string($data) ? $data : null;
         } catch (Throwable) {
             return null;
         } finally {

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -167,7 +167,7 @@ class AssetsController extends Controller
         $asset->folderPath = is_string($folder->path) ? Fs::urlEncodePathSegments($folder->path) : $asset->folderPath;
 
         $asset->size = $this->uploadedAssetSize($asset, $filename);
-        [$asset->width, $asset->height] = $this->uploadedImageDimensions($asset, $filename);
+        [$asset->width, $asset->height] = $this->uploadedImageDimensions($asset);
 
         if (!$selectionCondition) {
             $asset->newFilename = $targetFilename;
@@ -349,7 +349,7 @@ class AssetsController extends Controller
         $asset->avoidFilenameConflicts = true;
         $asset->setScenario(Asset::SCENARIO_REPLACE);
         $asset->setFilename($filename);
-        [$asset->width, $asset->height] = $this->uploadedImageDimensions($asset, $filename);
+        [$asset->width, $asset->height] = $this->uploadedImageDimensions($asset);
         $asset->newFilename = $targetFilename;
 
         $saved = $this->saveAsset($asset);
@@ -403,12 +403,8 @@ class AssetsController extends Controller
         return $size;
     }
 
-    protected function uploadedImageDimensions(Asset $asset, string $filename): array
+    protected function uploadedImageDimensions(Asset $asset): array
     {
-        if (Assets::getFileKindByExtension($filename) !== Asset::KIND_IMAGE) {
-            return [null, null];
-        }
-
         return $this->readUploadedImageDimensions($asset) ?? [null, null];
     }
 

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -11,11 +11,9 @@ use craft\events\ReplaceAssetEvent;
 use craft\fields\Assets as AssetsField;
 use craft\helpers\Assets;
 use craft\helpers\Db;
-use craft\helpers\Image;
 use craft\models\Volume;
 use craft\web\Controller;
 use DateTime;
-use Throwable;
 use yii\base\Event;
 use yii\base\Exception;
 use yii\base\Model;
@@ -26,8 +24,6 @@ use yii\web\Response;
 class AssetsController extends Controller
 {
     use AssetsControllerTrait;
-
-    private const IMAGE_DIMENSION_HEADER_BYTES = 1048576;
 
     public function actionGetUploadUrl(): Response
     {
@@ -418,85 +414,12 @@ class AssetsController extends Controller
 
     protected function readUploadedImageDimensions(Asset $asset): ?array
     {
-        $stream = $this->uploadedImageHeaderStream($asset);
+        $fs = $asset->getVolume()->getFs();
 
-        if ($stream === null) {
+        if (!$fs instanceof Fs) {
             return null;
         }
 
-        try {
-            $imageSize = Image::imageSizeByStream($stream);
-
-            if ($imageSize === false || !isset($imageSize[0], $imageSize[1])) {
-                return null;
-            }
-
-            return [
-                (int)$imageSize[0] ?: null,
-                (int)$imageSize[1] ?: null,
-            ];
-        } catch (Throwable) {
-            return null;
-        } finally {
-            if (is_resource($stream)) {
-                fclose($stream);
-            }
-        }
-    }
-
-    /**
-     * @return resource|null
-     */
-    protected function uploadedImageHeaderStream(Asset $asset)
-    {
-        $sourceStream = null;
-
-        try {
-            $fs = $asset->getVolume()->getFs();
-
-            if ($fs instanceof Fs && !$fs->useLocalFs) {
-                $bucket = $fs->getBucketName();
-
-                if ($bucket === null) {
-                    return null;
-                }
-
-                $object = $fs->getClient()->getObject([
-                    'Bucket' => $bucket,
-                    'Key' => $fs->createBucketPath($asset->getPath())->toString(),
-                    'Range' => sprintf('bytes=0-%d', self::IMAGE_DIMENSION_HEADER_BYTES - 1),
-                ]);
-
-                return $this->stringStream((string)$object->get('Body'));
-            }
-
-            $sourceStream = $fs->getFileStream($asset->getPath());
-            $data = stream_get_contents($sourceStream, self::IMAGE_DIMENSION_HEADER_BYTES);
-
-            return is_string($data) ? $this->stringStream($data) : null;
-        } catch (Throwable) {
-            return null;
-        } finally {
-            if (is_resource($sourceStream)) {
-                fclose($sourceStream);
-            }
-        }
-    }
-
-    /**
-     * @return resource|null
-     */
-    private function stringStream(string $contents)
-    {
-        $stream = fopen('php://temp', 'r+');
-
-        if ($stream === false) {
-            return null;
-        }
-
-        fwrite($stream, $contents);
-        rewind($stream);
-
-        return $stream;
+        return $fs->getImageDimensions($asset->getPath());
     }
 }

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -10,6 +10,7 @@ use craft\behaviors\EnvAttributeParserBehavior;
 use craft\cloud\Module;
 use craft\cloud\StaticCache;
 use craft\cloud\StaticCacheTag;
+use craft\elements\Asset;
 use craft\errors\FsException;
 use craft\flysystem\base\FlysystemFs;
 use craft\fs\Local;
@@ -524,6 +525,10 @@ abstract class Fs extends FlysystemFs
 
     public function getImageDimensions(string $uriPath): ?array
     {
+        if (Assets::getFileKindByExtension($uriPath) !== Asset::KIND_IMAGE) {
+            return null;
+        }
+
         $stream = $this->getFileStreamRange($uriPath, 0, self::IMAGE_DIMENSION_HEADER_BYTES - 1);
 
         if ($stream === null) {

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -559,25 +559,25 @@ abstract class Fs extends FlysystemFs
             return null;
         }
 
-        if (!$this->useLocalFs) {
-            $bucket = $this->getBucketName();
-
-            if ($bucket === null) {
-                return null;
-            }
-
-            $object = $this->getClient()->getObject([
-                'Bucket' => $bucket,
-                'Key' => $this->createBucketPath($uriPath)->toString(),
-                'Range' => "bytes=$start-$end",
-            ]);
-
-            return $this->stringStream((string)$object->get('Body'));
-        }
-
         $sourceStream = null;
 
         try {
+            if (!$this->useLocalFs) {
+                $bucket = $this->getBucketName();
+
+                if ($bucket === null) {
+                    return null;
+                }
+
+                $object = $this->getClient()->getObject([
+                    'Bucket' => $bucket,
+                    'Key' => $this->createBucketPath($uriPath)->toString(),
+                    'Range' => "bytes=$start-$end",
+                ]);
+
+                return $this->stringStream((string)$object->get('Body'));
+            }
+
             $sourceStream = $this->getFileStream($uriPath);
 
             if (fseek($sourceStream, $start) === -1) {
@@ -587,6 +587,8 @@ abstract class Fs extends FlysystemFs
             $data = stream_get_contents($sourceStream, $end - $start + 1);
 
             return is_string($data) ? $this->stringStream($data) : null;
+        } catch (Throwable) {
+            return null;
         } finally {
             if (is_resource($sourceStream)) {
                 fclose($sourceStream);

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -16,6 +16,7 @@ use craft\fs\Local;
 use craft\helpers\App;
 use craft\helpers\Assets;
 use craft\helpers\DateTimeHelper;
+use craft\helpers\Image;
 use DateTime;
 use DateTimeInterface;
 use Generator;
@@ -37,6 +38,8 @@ use yii\base\InvalidConfigException;
  */
 abstract class Fs extends FlysystemFs
 {
+    private const IMAGE_DIMENSION_HEADER_BYTES = 1048576;
+
     protected static bool $showUrlSetting = false;
     protected ?string $expires = null;
     protected ?Local $localFs = null;
@@ -517,6 +520,95 @@ abstract class Fs extends FlysystemFs
         }
 
         return parent::getFileStream($uriPath);
+    }
+
+    public function getImageDimensions(string $uriPath): ?array
+    {
+        $stream = $this->getFileStreamRange($uriPath, 0, self::IMAGE_DIMENSION_HEADER_BYTES - 1);
+
+        if ($stream === null) {
+            return null;
+        }
+
+        try {
+            $imageSize = Image::imageSizeByStream($stream);
+
+            if ($imageSize === false || !isset($imageSize[0], $imageSize[1])) {
+                return null;
+            }
+
+            return [
+                (int)$imageSize[0] ?: null,
+                (int)$imageSize[1] ?: null,
+            ];
+        } catch (Throwable) {
+            return null;
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+    }
+
+    /**
+     * @return resource|null
+     */
+    public function getFileStreamRange(string $uriPath, int $start, int $end)
+    {
+        if ($start < 0 || $end < $start) {
+            return null;
+        }
+
+        if (!$this->useLocalFs) {
+            $bucket = $this->getBucketName();
+
+            if ($bucket === null) {
+                return null;
+            }
+
+            $object = $this->getClient()->getObject([
+                'Bucket' => $bucket,
+                'Key' => $this->createBucketPath($uriPath)->toString(),
+                'Range' => "bytes=$start-$end",
+            ]);
+
+            return $this->stringStream((string)$object->get('Body'));
+        }
+
+        $sourceStream = null;
+
+        try {
+            $sourceStream = $this->getFileStream($uriPath);
+
+            if (fseek($sourceStream, $start) === -1) {
+                return null;
+            }
+
+            $data = stream_get_contents($sourceStream, $end - $start + 1);
+
+            return is_string($data) ? $this->stringStream($data) : null;
+        } finally {
+            if (is_resource($sourceStream)) {
+                fclose($sourceStream);
+            }
+        }
+    }
+
+    /**
+     * @return resource|null
+     */
+    private function stringStream(string $contents)
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        if ($stream === false) {
+            return null;
+        }
+
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        return $stream;
     }
 
     /**

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -43,27 +43,13 @@ class AssetsControllerTest extends Unit
         $this->assertSame('volume-prefix/', $this->invokeVolumeSubpath($volume));
     }
 
-    public function testImageUploadsUseUploadedImageDimensions(): void
+    public function testImageDimensionsUseNullWhenUploadedImageDimensionsCannotBeRead(): void
     {
-        $controller = new DimensionTestAssetsController('cloud-assets', Craft::$app);
-        $controller->uploadedImageDimensions = [2139, 3020];
+        $fs = new HeaderTestFs();
+        $fs->header = 'not image data';
 
-        $this->assertSame([2139, 3020], $controller->uploadedImageDimensionsForTest(
-            new Asset(),
-            'upload.jpeg',
-        ));
-        $this->assertSame(1, $controller->readCount);
-    }
-
-    public function testImageUploadsUseNullDimensionsWhenUploadedImageDimensionsCannotBeRead(): void
-    {
-        $controller = new DimensionTestAssetsController('cloud-assets', Craft::$app);
-
-        $this->assertSame([null, null], $controller->uploadedImageDimensionsForTest(
-            new Asset(),
-            'upload.jpeg',
-        ));
-        $this->assertSame(1, $controller->readCount);
+        $this->assertNull($fs->getImageDimensions('upload.jpeg'));
+        $this->assertSame(1, $fs->readCount);
     }
 
     public function testNonImageUploadsUseNullDimensions(): void
@@ -73,21 +59,6 @@ class AssetsControllerTest extends Unit
 
         $this->assertNull($fs->getImageDimensions('document.pdf'));
         $this->assertSame(0, $fs->readCount);
-    }
-
-    public function testReplacementUploadsUseServerDimensionsForUploadedFile(): void
-    {
-        $asset = new Asset();
-        $asset->folderPath = 'uploads';
-
-        $controller = new DimensionTestAssetsController('cloud-assets', Craft::$app);
-        $controller->uploadedImageDimensions = [1080, 1440];
-
-        $this->assertSame([1080, 1440], $controller->uploadedImageDimensionsForTest(
-            $asset,
-            'upload-replacement.jpeg',
-        ));
-        $this->assertSame(1, $controller->readCount);
     }
 
     public function testUploadedAssetSizeUsesActualVolumeSize(): void
@@ -134,26 +105,9 @@ class AssetsControllerTest extends Unit
 
 class DimensionTestAssetsController extends AssetsController
 {
-    public ?array $uploadedImageDimensions = null;
-    public int $readCount = 0;
-
-    public function uploadedImageDimensionsForTest(Asset $asset, string $filename): array
-    {
-        $asset->setFilename($filename);
-
-        return $this->uploadedImageDimensions($asset);
-    }
-
     public function uploadedAssetSizeForTest(Asset $asset, string $filename): int
     {
         return $this->uploadedAssetSize($asset, $filename);
-    }
-
-    protected function readUploadedImageDimensions(Asset $asset): ?array
-    {
-        $this->readCount++;
-
-        return $this->uploadedImageDimensions;
     }
 }
 

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -114,12 +114,14 @@ class AssetsControllerTest extends Unit
 
     public function testImageDimensionsCanBeReadFromBoundedJpegHeader(): void
     {
-        $controller = new DimensionTestAssetsController('cloud-assets', Craft::$app);
+        $controller = new HeaderTestAssetsController('cloud-assets', Craft::$app);
         $jpeg = "\xFF\xD8"
             . "\xFF\xE1" . pack('n', 4) . 'xx'
             . "\xFF\xC0" . pack('n', 17) . "\x08" . pack('n', 3020) . pack('n', 2139) . str_repeat("\0", 10);
 
-        $this->assertSame([2139, 3020], $controller->imageDimensionsFromHeaderForTest($jpeg));
+        $controller->header = $jpeg;
+
+        $this->assertSame([2139, 3020], $controller->readUploadedImageDimensionsForTest(new Asset()));
     }
 
     private function invokeVolumeSubpath(Volume $volume): string
@@ -149,16 +151,35 @@ class DimensionTestAssetsController extends AssetsController
         return $this->uploadedAssetSize($asset, $filename);
     }
 
-    public function imageDimensionsFromHeaderForTest(string|false $data): ?array
-    {
-        return $this->imageDimensionsFromHeader($data);
-    }
-
     protected function readUploadedImageDimensions(Asset $asset): ?array
     {
         $this->readCount++;
 
         return $this->uploadedImageDimensions;
+    }
+}
+
+class HeaderTestAssetsController extends AssetsController
+{
+    public string $header;
+
+    public function readUploadedImageDimensionsForTest(Asset $asset): ?array
+    {
+        return $this->readUploadedImageDimensions($asset);
+    }
+
+    protected function uploadedImageHeaderStream(Asset $asset)
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        if ($stream === false) {
+            return null;
+        }
+
+        fwrite($stream, $this->header);
+        rewind($stream);
+
+        return $stream;
     }
 }
 

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -68,14 +68,11 @@ class AssetsControllerTest extends Unit
 
     public function testNonImageUploadsUseNullDimensions(): void
     {
-        $controller = new DimensionTestAssetsController('cloud-assets', Craft::$app);
-        $controller->uploadedImageDimensions = [2139, 3020];
+        $fs = new HeaderTestFs();
+        $fs->header = 'not image data';
 
-        $this->assertSame([null, null], $controller->uploadedImageDimensionsForTest(
-            new Asset(),
-            'document.pdf',
-        ));
-        $this->assertSame(0, $controller->readCount);
+        $this->assertNull($fs->getImageDimensions('document.pdf'));
+        $this->assertSame(0, $fs->readCount);
     }
 
     public function testReplacementUploadsUseServerDimensionsForUploadedFile(): void
@@ -144,7 +141,7 @@ class DimensionTestAssetsController extends AssetsController
     {
         $asset->setFilename($filename);
 
-        return $this->uploadedImageDimensions($asset, $filename);
+        return $this->uploadedImageDimensions($asset);
     }
 
     public function uploadedAssetSizeForTest(Asset $asset, string $filename): int
@@ -163,6 +160,7 @@ class DimensionTestAssetsController extends AssetsController
 class HeaderTestFs extends Fs
 {
     public string $header;
+    public int $readCount = 0;
 
     public static function displayName(): string
     {
@@ -171,6 +169,8 @@ class HeaderTestFs extends Fs
 
     public function getFileStreamRange(string $uriPath, int $start, int $end)
     {
+        $this->readCount++;
+
         $stream = fopen('php://temp', 'r+');
 
         if ($stream === false) {

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -5,6 +5,7 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\controllers\AssetsController;
+use craft\cloud\fs\Fs;
 use craft\elements\Asset;
 use craft\helpers\Assets as AssetsHelper;
 use craft\models\Volume;
@@ -114,14 +115,14 @@ class AssetsControllerTest extends Unit
 
     public function testImageDimensionsCanBeReadFromBoundedJpegHeader(): void
     {
-        $controller = new HeaderTestAssetsController('cloud-assets', Craft::$app);
+        $fs = new HeaderTestFs();
         $jpeg = "\xFF\xD8"
             . "\xFF\xE1" . pack('n', 4) . 'xx'
             . "\xFF\xC0" . pack('n', 17) . "\x08" . pack('n', 3020) . pack('n', 2139) . str_repeat("\0", 10);
 
-        $controller->header = $jpeg;
+        $fs->header = $jpeg;
 
-        $this->assertSame([2139, 3020], $controller->readUploadedImageDimensionsForTest(new Asset()));
+        $this->assertSame([2139, 3020], $fs->getImageDimensions('upload.jpeg'));
     }
 
     private function invokeVolumeSubpath(Volume $volume): string
@@ -159,16 +160,16 @@ class DimensionTestAssetsController extends AssetsController
     }
 }
 
-class HeaderTestAssetsController extends AssetsController
+class HeaderTestFs extends Fs
 {
     public string $header;
 
-    public function readUploadedImageDimensionsForTest(Asset $asset): ?array
+    public static function displayName(): string
     {
-        return $this->readUploadedImageDimensions($asset);
+        return 'Header Test';
     }
 
-    protected function uploadedImageHeaderStream(Asset $asset)
+    public function getFileStreamRange(string $uriPath, int $start, int $end)
     {
         $stream = fopen('php://temp', 'r+');
 

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -6,8 +6,10 @@ use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\controllers\AssetsController;
 use craft\elements\Asset;
+use craft\helpers\Assets as AssetsHelper;
 use craft\models\Volume;
 use ReflectionMethod;
+use yii\web\BadRequestHttpException;
 
 class AssetsControllerTest extends Unit
 {
@@ -90,6 +92,36 @@ class AssetsControllerTest extends Unit
         $this->assertSame(1, $controller->readCount);
     }
 
+    public function testUploadedAssetSizeUsesActualVolumeSize(): void
+    {
+        $controller = new DimensionTestAssetsController('cloud-assets', Craft::$app);
+        $asset = new SizeTestAsset(123);
+        $asset->setFilename('upload.jpeg');
+
+        $this->assertSame(123, $controller->uploadedAssetSizeForTest($asset, 'upload.jpeg'));
+    }
+
+    public function testUploadedAssetSizeRejectsOversizedActualFile(): void
+    {
+        $controller = new DimensionTestAssetsController('cloud-assets', Craft::$app);
+        $asset = new SizeTestAsset((int)AssetsHelper::getMaxUploadSize() + 1);
+        $asset->setFilename('upload.jpeg');
+
+        $this->expectException(BadRequestHttpException::class);
+
+        $controller->uploadedAssetSizeForTest($asset, 'upload.jpeg');
+    }
+
+    public function testImageDimensionsCanBeReadFromBoundedJpegHeader(): void
+    {
+        $controller = new DimensionTestAssetsController('cloud-assets', Craft::$app);
+        $jpeg = "\xFF\xD8"
+            . "\xFF\xE1" . pack('n', 4) . 'xx'
+            . "\xFF\xC0" . pack('n', 17) . "\x08" . pack('n', 3020) . pack('n', 2139) . str_repeat("\0", 10);
+
+        $this->assertSame([2139, 3020], $controller->imageDimensionsFromHeaderForTest($jpeg));
+    }
+
     private function invokeVolumeSubpath(Volume $volume): string
     {
         $controller = new AssetsController('cloud-assets', Craft::$app);
@@ -112,10 +144,51 @@ class DimensionTestAssetsController extends AssetsController
         return $this->uploadedImageDimensions($asset, $filename);
     }
 
+    public function uploadedAssetSizeForTest(Asset $asset, string $filename): int
+    {
+        return $this->uploadedAssetSize($asset, $filename);
+    }
+
+    public function imageDimensionsFromHeaderForTest(string|false $data): ?array
+    {
+        return $this->imageDimensionsFromHeader($data);
+    }
+
     protected function readUploadedImageDimensions(Asset $asset): ?array
     {
         $this->readCount++;
 
         return $this->uploadedImageDimensions;
+    }
+}
+
+class SizeTestAsset extends Asset
+{
+    private int $fileSize;
+
+    public function __construct(int $fileSize)
+    {
+        $this->fileSize = $fileSize;
+
+        parent::__construct();
+    }
+
+    public function getVolume(): Volume
+    {
+        return new class($this->fileSize) extends Volume {
+            private int $fileSize;
+
+            public function __construct(int $fileSize)
+            {
+                $this->fileSize = $fileSize;
+
+                parent::__construct();
+            }
+
+            public function getFileSize(string $uri): int
+            {
+                return $this->fileSize;
+            }
+        };
     }
 }


### PR DESCRIPTION
### Description
Keeps Cloud asset metadata reads bounded and server-owned after direct uploads.

This avoids trusting browser-reported file metadata and prevents image probing from pulling full uploaded objects through the app worker.