### PR TITLE
[3.x] Use native transforms for action requests

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -97,7 +97,7 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 Asset::class,
                 Asset::EVENT_BEFORE_GENERATE_TRANSFORM,
                 function(GenerateTransformEvent $event) {
-                    if (!$event->transform || !$event->asset?->fs instanceof AssetsFs) {
+                    if (!$this->shouldUseAssetCdnTransform($event)) {
                         return;
                     }
 
@@ -117,6 +117,19 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 $app->getView()->registerAssetBundle(UploaderAsset::class);
             }
         }
+    }
+
+    protected function shouldUseAssetCdnTransform(GenerateTransformEvent $event): bool
+    {
+        if (!$event->transform || !$event->asset?->fs instanceof AssetsFs) {
+            return false;
+        }
+
+        if (!(Craft::$app instanceof WebApplication)) {
+            return true;
+        }
+
+        return !Craft::$app->getRequest()->getIsActionRequest();
     }
 
     public function getConfig(): Config

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -94,7 +94,7 @@ abstract class Fs extends FlysystemFs
     {
         if ($this->useLocalFs) {
             return Modifier::wrap($this->getLocalFs()->getRootUrl() ?? '/')
-                ->appendSegment($this->createPath($path))
+                ->appendPath($this->createPath($path))
                 ->unwrap();
         }
 

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -5,10 +5,13 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\Module as CloudModule;
+use craft\cloud\fs\AssetsFs;
 use craft\cloud\imagetransforms\ImageTransformBehavior;
 use craft\cloud\imagetransforms\ImageTransformer;
 use craft\elements\Asset;
+use craft\events\GenerateTransformEvent;
 use craft\models\ImageTransform;
+use craft\models\Volume;
 
 class ImageTransformTest extends Unit
 {
@@ -123,6 +126,27 @@ class ImageTransformTest extends Unit
         $this->assertStringNotContainsString('gravity%5Bx%5D=0.57', $secondUrl);
     }
 
+    public function testActionRequestsUseNativeTransforms(): void
+    {
+        $module = new TestCloudModule('cloud-test');
+        $event = new GenerateTransformEvent([
+            'asset' => new TransformDecisionAsset(),
+            'transform' => new ImageTransform(['width' => 100]),
+        ]);
+        $request = Craft::$app->getRequest();
+        $isActionRequest = $request->getIsActionRequest();
+
+        try {
+            $request->setIsActionRequest(true);
+            $this->assertFalse($module->usesAssetCdnTransform($event));
+
+            $request->setIsActionRequest(false);
+            $this->assertTrue($module->usesAssetCdnTransform($event));
+        } finally {
+            $request->setIsActionRequest($isActionRequest);
+        }
+    }
+
     private function makeAssetStub(array $focalPoint): Asset
     {
         return new class($focalPoint) extends Asset {
@@ -176,7 +200,7 @@ class ImageTransformTest extends Unit
                 return $this->focalPointValue;
             }
 
-            public function getWidth(array|string|\craft\models\ImageTransform $transform = null): ?int
+            public function getWidth(array|string|\craft\models\ImageTransform|null $transform = null): ?int
             {
                 return $this->widthValue;
             }
@@ -232,5 +256,26 @@ class UrlTestImageTransformer extends ImageTransformer
         $behavior = $imageTransform->getBehavior('cloud');
 
         return (string) \League\Uri\Components\Query::fromVariable($behavior->toOptions($gravity));
+    }
+}
+
+class TestCloudModule extends CloudModule
+{
+    public function usesAssetCdnTransform(GenerateTransformEvent $event): bool
+    {
+        return $this->shouldUseAssetCdnTransform($event);
+    }
+}
+
+class TransformDecisionAsset extends Asset
+{
+    public function getVolume(): Volume
+    {
+        return new class() extends Volume {
+            public function getFs(): AssetsFs
+            {
+                return new AssetsFs();
+            }
+        };
     }
 }


### PR DESCRIPTION
### Description
Skip Cloud’s asset CDN transform override during Craft action requests so handlers like the image editor use Craft’s native transform pipeline.

This keeps image-editor preview URLs and server-side save/crop behavior in the same coordinate space, matching native Craft behavior for unsanitized CP uploads.