### PR TITLE
[3.x] Expand static cache tag to all non-cp requests

### DIFF
--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -321,6 +321,7 @@ class StaticCache extends \yii\base\Component
         $response = Craft::$app->getResponse();
 
         return
+            ($request->getIsGet() || $request->getIsHead()) &&
             !$request->getIsCpRequest() &&
             $response instanceof \craft\web\Response &&
             $response->getIsOk();

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -39,6 +39,7 @@ class StaticCache extends \yii\base\Component
     private Collection $tags;
     private Collection $tagsToPurge;
     private bool $collectingCacheInfo = false;
+    private bool $renderedPageTemplate = false;
 
     public function init(): void
     {
@@ -133,6 +134,8 @@ class StaticCache extends \yii\base\Component
 
     private function handleBeforeRenderPageTemplate(TemplateEvent $event): void
     {
+        $this->renderedPageTemplate = true;
+
         /** @var UrlManager $urlManager */
         $urlManager = Craft::$app->getUrlManager();
         $matchedElement = $urlManager->getMatchedElement();
@@ -210,8 +213,19 @@ class StaticCache extends \yii\base\Component
 
     private function addCacheHeadersToWebResponse(): void
     {
-        $this->cacheDuration = $this->cacheDuration ?? Module::getInstance()->getConfig()->staticCacheDuration;
         $headers = Craft::$app->getResponse()->getHeaders();
+
+        // Capture and remove any existing headers, so we can prepare them
+        $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? []);
+        $headers->remove(HeaderEnum::CACHE_TAG->value);
+        $this->tags->push(...$existingTagsFromHeader);
+        $this->tags = $this->prepareTags(...$this->tags);
+
+        if ($this->tags->isEmpty() && !$this->renderedPageTemplate) {
+            return;
+        }
+
+        $this->cacheDuration = $this->cacheDuration ?? Module::getInstance()->getConfig()->staticCacheDuration;
 
         $cacheControlDirectives = Collection::make($headers->get(
             HeaderEnum::CACHE_CONTROL->value,
@@ -233,12 +247,6 @@ class StaticCache extends \yii\base\Component
             HeaderEnum::CDN_CACHE_CONTROL->value,
             $cdnCacheControlDirectives->implode(','),
         );
-
-        // Capture and remove any existing headers, so we can prepare them
-        $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? []);
-        $headers->remove(HeaderEnum::CACHE_TAG->value);
-        $this->tags->push(...$existingTagsFromHeader);
-        $this->tags = $this->prepareTags(...$this->tags);
 
         Craft::info(new PsrMessage('Adding cache tags to response', [
             'tags' => $this->tags,
@@ -312,10 +320,11 @@ class StaticCache extends \yii\base\Component
 
     private function isCacheable(): bool
     {
+        $request = Craft::$app->getRequest();
         $response = Craft::$app->getResponse();
 
         return
-            Craft::$app->getView()->templateMode === View::TEMPLATE_MODE_SITE &&
+            !$request->getIsCpRequest() &&
             $response instanceof \craft\web\Response &&
             $response->getIsOk();
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -210,15 +210,8 @@ class StaticCache extends \yii\base\Component
 
     private function addCacheHeadersToWebResponse(): void
     {
-        $headers = Craft::$app->getResponse()->getHeaders();
-
-        // Capture and remove any existing headers, so we can prepare them
-        $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? []);
-        $headers->remove(HeaderEnum::CACHE_TAG->value);
-        $this->tags->push(...$existingTagsFromHeader);
-        $this->tags = $this->prepareTags(...$this->tags);
-
         $this->cacheDuration = $this->cacheDuration ?? Module::getInstance()->getConfig()->staticCacheDuration;
+        $headers = Craft::$app->getResponse()->getHeaders();
 
         $cacheControlDirectives = Collection::make($headers->get(
             HeaderEnum::CACHE_CONTROL->value,
@@ -240,6 +233,12 @@ class StaticCache extends \yii\base\Component
             HeaderEnum::CDN_CACHE_CONTROL->value,
             $cdnCacheControlDirectives->implode(','),
         );
+
+        // Capture and remove any existing headers, so we can prepare them
+        $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? []);
+        $headers->remove(HeaderEnum::CACHE_TAG->value);
+        $this->tags->push(...$existingTagsFromHeader);
+        $this->tags = $this->prepareTags(...$this->tags);
 
         Craft::info(new PsrMessage('Adding cache tags to response', [
             'tags' => $this->tags,

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -39,7 +39,6 @@ class StaticCache extends \yii\base\Component
     private Collection $tags;
     private Collection $tagsToPurge;
     private bool $collectingCacheInfo = false;
-    private bool $renderedPageTemplate = false;
 
     public function init(): void
     {
@@ -134,8 +133,6 @@ class StaticCache extends \yii\base\Component
 
     private function handleBeforeRenderPageTemplate(TemplateEvent $event): void
     {
-        $this->renderedPageTemplate = true;
-
         /** @var UrlManager $urlManager */
         $urlManager = Craft::$app->getUrlManager();
         $matchedElement = $urlManager->getMatchedElement();
@@ -221,7 +218,7 @@ class StaticCache extends \yii\base\Component
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->prepareTags(...$this->tags);
 
-        if ($this->tags->isEmpty() && !$this->renderedPageTemplate) {
+        if ($this->tags->isEmpty()) {
             return;
         }
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -218,10 +218,6 @@ class StaticCache extends \yii\base\Component
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->prepareTags(...$this->tags);
 
-        if ($this->tags->isEmpty()) {
-            return;
-        }
-
         $this->cacheDuration = $this->cacheDuration ?? Module::getInstance()->getConfig()->staticCacheDuration;
 
         $cacheControlDirectives = Collection::make($headers->get(

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -4,8 +4,6 @@ namespace craft\cloud\tests\unit;
 
 use Codeception\Test\Unit;
 use Craft;
-use craft\cloud\HeaderEnum;
-use craft\cloud\Module as CloudModule;
 use craft\cloud\StaticCache;
 use ReflectionMethod;
 
@@ -21,11 +19,6 @@ class StaticCacheTest extends Unit
     protected function _before(): void
     {
         parent::_before();
-
-        if (CloudModule::getInstance() === null) {
-            $module = new CloudModule('cloud');
-            $module->bootstrap(Craft::$app);
-        }
 
         Craft::$app->getRequest()->setIsCpRequest(false);
         Craft::$app->getResponse()->clear();
@@ -49,27 +42,6 @@ class StaticCacheTest extends Unit
         parent::_after();
     }
 
-    public function testNonTemplateResponseWithoutTagsAddsCacheHeaders(): void
-    {
-        $this->addCacheHeadersToWebResponse(new StaticCache());
-
-        $headers = Craft::$app->getResponse()->getHeaders();
-
-        $this->assertMatchesRegularExpression('/^public,max-age=\d+,stale-while-revalidate=3600$/', $headers->get(HeaderEnum::CDN_CACHE_CONTROL->value));
-        $this->assertFalse($headers->has(HeaderEnum::CACHE_TAG->value));
-    }
-
-    public function testNonTemplateResponseWithTagsAddsCacheHeaders(): void
-    {
-        $headers = Craft::$app->getResponse()->getHeaders();
-        $headers->add(HeaderEnum::CACHE_TAG->value, 'headless-tag');
-
-        $this->addCacheHeadersToWebResponse(new StaticCache());
-
-        $this->assertMatchesRegularExpression('/^public,max-age=\d+,stale-while-revalidate=3600$/', $headers->get(HeaderEnum::CDN_CACHE_CONTROL->value));
-        $this->assertSame(['headless-tag'], $headers->get(HeaderEnum::CACHE_TAG->value, first: false));
-    }
-
     public function testCpResponsesAreNotCacheable(): void
     {
         $staticCache = new StaticCache();
@@ -79,24 +51,15 @@ class StaticCacheTest extends Unit
         $this->assertFalse($this->isCacheable($staticCache));
     }
 
-    public function testGetSiteResponsesAreCacheable(): void
+    public function testReadResponsesAreCacheable(): void
     {
         $staticCache = new StaticCache();
 
-        Craft::$app->getRequest()->setIsCpRequest(false);
-        $_SERVER['REQUEST_METHOD'] = 'GET';
+        foreach (['GET', 'HEAD'] as $method) {
+            $_SERVER['REQUEST_METHOD'] = $method;
 
-        $this->assertTrue($this->isCacheable($staticCache));
-    }
-
-    public function testHeadSiteResponsesAreCacheable(): void
-    {
-        $staticCache = new StaticCache();
-
-        Craft::$app->getRequest()->setIsCpRequest(false);
-        $_SERVER['REQUEST_METHOD'] = 'HEAD';
-
-        $this->assertTrue($this->isCacheable($staticCache));
+            $this->assertTrue($this->isCacheable($staticCache));
+        }
     }
 
     public function testPostResponsesAreNotCacheable(): void
@@ -106,22 +69,6 @@ class StaticCacheTest extends Unit
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
         $this->assertFalse($this->isCacheable($staticCache));
-    }
-
-    public function testErrorResponsesAreNotCacheable(): void
-    {
-        $staticCache = new StaticCache();
-
-        Craft::$app->getResponse()->setStatusCode(500);
-
-        $this->assertFalse($this->isCacheable($staticCache));
-    }
-
-    private function addCacheHeadersToWebResponse(StaticCache $staticCache): void
-    {
-        $method = new ReflectionMethod($staticCache, 'addCacheHeadersToWebResponse');
-        $method->setAccessible(true);
-        $method->invoke($staticCache);
     }
 
     private function isCacheable(StaticCache $staticCache): bool

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -49,13 +49,13 @@ class StaticCacheTest extends Unit
         parent::_after();
     }
 
-    public function testNonTemplateResponseWithoutTagsDoesNotAddCacheHeaders(): void
+    public function testNonTemplateResponseWithoutTagsAddsCacheHeaders(): void
     {
         $this->addCacheHeadersToWebResponse(new StaticCache());
 
         $headers = Craft::$app->getResponse()->getHeaders();
 
-        $this->assertFalse($headers->has(HeaderEnum::CDN_CACHE_CONTROL->value));
+        $this->assertMatchesRegularExpression('/^public,max-age=\d+,stale-while-revalidate=3600$/', $headers->get(HeaderEnum::CDN_CACHE_CONTROL->value));
         $this->assertFalse($headers->has(HeaderEnum::CACHE_TAG->value));
     }
 

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -8,7 +8,6 @@ use craft\cloud\HeaderEnum;
 use craft\cloud\Module as CloudModule;
 use craft\cloud\StaticCache;
 use ReflectionMethod;
-use ReflectionProperty;
 
 class StaticCacheTest extends Unit
 {
@@ -60,19 +59,6 @@ class StaticCacheTest extends Unit
         $this->assertSame(['headless-tag'], $headers->get(HeaderEnum::CACHE_TAG->value, first: false));
     }
 
-    public function testTemplateResponseWithoutTagsStillAddsCacheHeaders(): void
-    {
-        $staticCache = new StaticCache();
-        $this->setRenderedPageTemplate($staticCache);
-
-        $this->addCacheHeadersToWebResponse($staticCache);
-
-        $headers = Craft::$app->getResponse()->getHeaders();
-
-        $this->assertMatchesRegularExpression('/^public,max-age=\d+,stale-while-revalidate=3600$/', $headers->get(HeaderEnum::CDN_CACHE_CONTROL->value));
-        $this->assertFalse($headers->has(HeaderEnum::CACHE_TAG->value));
-    }
-
     public function testCpResponsesAreNotCacheable(): void
     {
         $staticCache = new StaticCache();
@@ -115,10 +101,4 @@ class StaticCacheTest extends Unit
         return $method->invoke($staticCache);
     }
 
-    private function setRenderedPageTemplate(StaticCache $staticCache): void
-    {
-        $property = new ReflectionProperty($staticCache, 'renderedPageTemplate');
-        $property->setAccessible(true);
-        $property->setValue($staticCache, true);
-    }
 }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -16,6 +16,8 @@ class StaticCacheTest extends Unit
      */
     protected $tester;
 
+    private ?string $requestMethod = null;
+
     protected function _before(): void
     {
         parent::_before();
@@ -28,12 +30,21 @@ class StaticCacheTest extends Unit
         Craft::$app->getRequest()->setIsCpRequest(false);
         Craft::$app->getResponse()->clear();
         Craft::$app->getResponse()->setStatusCode(200);
+
+        $this->requestMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
     }
 
     protected function _after(): void
     {
         Craft::$app->getRequest()->setIsCpRequest(null);
         Craft::$app->getResponse()->clear();
+
+        if ($this->requestMethod === null) {
+            unset($_SERVER['REQUEST_METHOD']);
+        } else {
+            $_SERVER['REQUEST_METHOD'] = $this->requestMethod;
+        }
 
         parent::_after();
     }
@@ -68,13 +79,33 @@ class StaticCacheTest extends Unit
         $this->assertFalse($this->isCacheable($staticCache));
     }
 
-    public function testSiteResponsesAreCacheable(): void
+    public function testGetSiteResponsesAreCacheable(): void
     {
         $staticCache = new StaticCache();
 
         Craft::$app->getRequest()->setIsCpRequest(false);
+        $_SERVER['REQUEST_METHOD'] = 'GET';
 
         $this->assertTrue($this->isCacheable($staticCache));
+    }
+
+    public function testHeadSiteResponsesAreCacheable(): void
+    {
+        $staticCache = new StaticCache();
+
+        Craft::$app->getRequest()->setIsCpRequest(false);
+        $_SERVER['REQUEST_METHOD'] = 'HEAD';
+
+        $this->assertTrue($this->isCacheable($staticCache));
+    }
+
+    public function testPostResponsesAreNotCacheable(): void
+    {
+        $staticCache = new StaticCache();
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $this->assertFalse($this->isCacheable($staticCache));
     }
 
     public function testErrorResponsesAreNotCacheable(): void
@@ -100,5 +131,4 @@ class StaticCacheTest extends Unit
 
         return $method->invoke($staticCache);
     }
-
 }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace craft\cloud\tests\unit;
+
+use Codeception\Test\Unit;
+use Craft;
+use craft\cloud\HeaderEnum;
+use craft\cloud\Module as CloudModule;
+use craft\cloud\StaticCache;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class StaticCacheTest extends Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+
+    protected function _before(): void
+    {
+        parent::_before();
+
+        if (CloudModule::getInstance() === null) {
+            $module = new CloudModule('cloud');
+            $module->bootstrap(Craft::$app);
+        }
+
+        Craft::$app->getRequest()->setIsCpRequest(false);
+        Craft::$app->getResponse()->clear();
+        Craft::$app->getResponse()->setStatusCode(200);
+    }
+
+    protected function _after(): void
+    {
+        Craft::$app->getRequest()->setIsCpRequest(null);
+        Craft::$app->getResponse()->clear();
+
+        parent::_after();
+    }
+
+    public function testNonTemplateResponseWithoutTagsDoesNotAddCacheHeaders(): void
+    {
+        $this->addCacheHeadersToWebResponse(new StaticCache());
+
+        $headers = Craft::$app->getResponse()->getHeaders();
+
+        $this->assertFalse($headers->has(HeaderEnum::CDN_CACHE_CONTROL->value));
+        $this->assertFalse($headers->has(HeaderEnum::CACHE_TAG->value));
+    }
+
+    public function testNonTemplateResponseWithTagsAddsCacheHeaders(): void
+    {
+        $headers = Craft::$app->getResponse()->getHeaders();
+        $headers->add(HeaderEnum::CACHE_TAG->value, 'headless-tag');
+
+        $this->addCacheHeadersToWebResponse(new StaticCache());
+
+        $this->assertMatchesRegularExpression('/^public,max-age=\d+,stale-while-revalidate=3600$/', $headers->get(HeaderEnum::CDN_CACHE_CONTROL->value));
+        $this->assertSame(['headless-tag'], $headers->get(HeaderEnum::CACHE_TAG->value, first: false));
+    }
+
+    public function testTemplateResponseWithoutTagsStillAddsCacheHeaders(): void
+    {
+        $staticCache = new StaticCache();
+        $this->setRenderedPageTemplate($staticCache);
+
+        $this->addCacheHeadersToWebResponse($staticCache);
+
+        $headers = Craft::$app->getResponse()->getHeaders();
+
+        $this->assertMatchesRegularExpression('/^public,max-age=\d+,stale-while-revalidate=3600$/', $headers->get(HeaderEnum::CDN_CACHE_CONTROL->value));
+        $this->assertFalse($headers->has(HeaderEnum::CACHE_TAG->value));
+    }
+
+    public function testCpResponsesAreNotCacheable(): void
+    {
+        $staticCache = new StaticCache();
+
+        Craft::$app->getRequest()->setIsCpRequest(true);
+
+        $this->assertFalse($this->isCacheable($staticCache));
+    }
+
+    public function testSiteResponsesAreCacheable(): void
+    {
+        $staticCache = new StaticCache();
+
+        Craft::$app->getRequest()->setIsCpRequest(false);
+
+        $this->assertTrue($this->isCacheable($staticCache));
+    }
+
+    public function testErrorResponsesAreNotCacheable(): void
+    {
+        $staticCache = new StaticCache();
+
+        Craft::$app->getResponse()->setStatusCode(500);
+
+        $this->assertFalse($this->isCacheable($staticCache));
+    }
+
+    private function addCacheHeadersToWebResponse(StaticCache $staticCache): void
+    {
+        $method = new ReflectionMethod($staticCache, 'addCacheHeadersToWebResponse');
+        $method->setAccessible(true);
+        $method->invoke($staticCache);
+    }
+
+    private function isCacheable(StaticCache $staticCache): bool
+    {
+        $method = new ReflectionMethod($staticCache, 'isCacheable');
+        $method->setAccessible(true);
+
+        return $method->invoke($staticCache);
+    }
+
+    private function setRenderedPageTemplate(StaticCache $staticCache): void
+    {
+        $property = new ReflectionProperty($staticCache, 'renderedPageTemplate');
+        $property->setAccessible(true);
+        $property->setValue($staticCache, true);
+    }
+}


### PR DESCRIPTION
### Description

Collects Craft static cache dependency tags for non-CP GET and HEAD responses, including headless routes such as GraphQL.

This lets asset changes purge cached headless responses without changing the existing gateway-level caching behavior for tagless responses.