### PR TITLE
[3.x] Skip session-backed static cache

### DIFF
--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -9,6 +9,7 @@ use craft\events\InvalidateElementCachesEvent;
 use craft\events\RegisterCacheOptionsEvent;
 use craft\events\TemplateEvent;
 use craft\helpers\ElementHelper;
+use craft\helpers\Session as SessionHelper;
 use craft\services\Elements;
 use craft\utilities\ClearCaches;
 use craft\web\UrlManager;
@@ -314,10 +315,12 @@ class StaticCache extends \yii\base\Component
     {
         $request = Craft::$app->getRequest();
         $response = Craft::$app->getResponse();
+        $user = Craft::$app->getUser();
 
         return
             ($request->getIsGet() || $request->getIsHead()) &&
             !$request->getIsCpRequest() &&
+            !SessionHelper::has($user->idParam) &&
             $response instanceof \craft\web\Response &&
             $response->getIsOk();
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -315,12 +315,11 @@ class StaticCache extends \yii\base\Component
     {
         $request = Craft::$app->getRequest();
         $response = Craft::$app->getResponse();
-        $user = Craft::$app->getUser();
 
         return
             ($request->getIsGet() || $request->getIsHead()) &&
             !$request->getIsCpRequest() &&
-            !SessionHelper::has($user->idParam) &&
+            !SessionHelper::exists() &&
             $response instanceof \craft\web\Response &&
             $response->getIsOk();
     }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -5,6 +5,7 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\StaticCache;
+use craft\helpers\Session as SessionHelper;
 use ReflectionMethod;
 
 class StaticCacheTest extends Unit
@@ -23,6 +24,7 @@ class StaticCacheTest extends Unit
         Craft::$app->getRequest()->setIsCpRequest(false);
         Craft::$app->getResponse()->clear();
         Craft::$app->getResponse()->setStatusCode(200);
+        SessionHelper::remove(Craft::$app->getUser()->idParam);
 
         $this->requestMethod = $_SERVER['REQUEST_METHOD'] ?? null;
         $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -32,6 +34,7 @@ class StaticCacheTest extends Unit
     {
         Craft::$app->getRequest()->setIsCpRequest(null);
         Craft::$app->getResponse()->clear();
+        SessionHelper::remove(Craft::$app->getUser()->idParam);
 
         if ($this->requestMethod === null) {
             unset($_SERVER['REQUEST_METHOD']);
@@ -47,6 +50,15 @@ class StaticCacheTest extends Unit
         $staticCache = new StaticCache();
 
         Craft::$app->getRequest()->setIsCpRequest(true);
+
+        $this->assertFalse($this->isCacheable($staticCache));
+    }
+
+    public function testAuthenticatedSessionsAreNotCacheable(): void
+    {
+        $staticCache = new StaticCache();
+
+        SessionHelper::set(Craft::$app->getUser()->idParam, 123);
 
         $this->assertFalse($this->isCacheable($staticCache));
     }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -24,7 +24,8 @@ class StaticCacheTest extends Unit
         Craft::$app->getRequest()->setIsCpRequest(false);
         Craft::$app->getResponse()->clear();
         Craft::$app->getResponse()->setStatusCode(200);
-        SessionHelper::remove(Craft::$app->getUser()->idParam);
+        Craft::$app->getSession()->setHasSessionId(false);
+        SessionHelper::reset();
 
         $this->requestMethod = $_SERVER['REQUEST_METHOD'] ?? null;
         $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -34,7 +35,8 @@ class StaticCacheTest extends Unit
     {
         Craft::$app->getRequest()->setIsCpRequest(null);
         Craft::$app->getResponse()->clear();
-        SessionHelper::remove(Craft::$app->getUser()->idParam);
+        Craft::$app->getSession()->setHasSessionId(false);
+        SessionHelper::reset();
 
         if ($this->requestMethod === null) {
             unset($_SERVER['REQUEST_METHOD']);
@@ -54,11 +56,11 @@ class StaticCacheTest extends Unit
         $this->assertFalse($this->isCacheable($staticCache));
     }
 
-    public function testAuthenticatedSessionsAreNotCacheable(): void
+    public function testSessionResponsesAreNotCacheable(): void
     {
         $staticCache = new StaticCache();
 
-        SessionHelper::set(Craft::$app->getUser()->idParam, 123);
+        Craft::$app->getSession()->setHasSessionId(true);
 
         $this->assertFalse($this->isCacheable($staticCache));
     }


### PR DESCRIPTION
### Description

Skips Cloud static cache headers when Craft has an existing PHP session.

This keeps the broader headless cache-tag collection from applying public CDN caching to session-backed frontend requests.