### PR TITLE
[3.x] Avoid bootstrap session cache checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "bref/extra-php-extensions": "^3",
     "craftcms/cms": "^4.6 || ^5",
     "craftcms/flysystem": "^1.0.0 || ^2.0.0",
+    "guzzlehttp/guzzle": "^7.4.5",
     "league/flysystem-aws-s3-v3": "^3.15",
     "league/uri": "^7.6",
     "league/uri-components": "^7.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b26b8aa4892c1dfa64bc47191b04d39b",
+    "content-hash": "dcd08efcfa79b08fba1ef27eeef85643",
     "packages": [
         {
             "name": "99designs/http-signatures",

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -308,20 +308,13 @@ class StaticCache extends \yii\base\Component
 
     private function staticCacheDirectives(): Collection
     {
-        $headers = Craft::$app->getResponse()->getHeaders();
-        $cdnCacheControlDirectives = Collection::make($headers->get(
-            HeaderEnum::CDN_CACHE_CONTROL->value,
-            first: false,
-        ) ?? []);
+        $cdnCacheControlDirectives = $this->headerDirectives(HeaderEnum::CDN_CACHE_CONTROL->value);
 
         if ($cdnCacheControlDirectives->isNotEmpty()) {
             return $cdnCacheControlDirectives;
         }
 
-        $cacheControlDirectives = Collection::make($headers->get(
-            HeaderEnum::CACHE_CONTROL->value,
-            first: false,
-        ) ?? []);
+        $cacheControlDirectives = $this->headerDirectives(HeaderEnum::CACHE_CONTROL->value);
 
         if ($cacheControlDirectives->isNotEmpty()) {
             return $cacheControlDirectives;
@@ -335,6 +328,23 @@ class StaticCache extends \yii\base\Component
             "max-age=$this->cacheDuration",
             "stale-while-revalidate=$swrDuration",
         ]);
+    }
+
+    private function headerDirectives(string $name): Collection
+    {
+        $headers = Craft::$app->getResponse()->getHeaders();
+        $directives = Collection::make($headers->get($name, first: false) ?? []);
+
+        if ($directives->isNotEmpty()) {
+            return $directives;
+        }
+
+        return Collection::make(headers_list())
+            ->filter(fn(string $header) => str_starts_with(
+                strtolower($header),
+                strtolower("$name:"),
+            ))
+            ->map(fn(string $header) => trim(substr($header, strlen($name) + 1)));
     }
 
     private function prepareTags(string|StaticCacheTag ...$tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -9,7 +9,6 @@ use craft\events\InvalidateElementCachesEvent;
 use craft\events\RegisterCacheOptionsEvent;
 use craft\events\TemplateEvent;
 use craft\helpers\ElementHelper;
-use craft\helpers\Session as SessionHelper;
 use craft\services\Elements;
 use craft\utilities\ClearCaches;
 use craft\web\UrlManager;
@@ -319,7 +318,6 @@ class StaticCache extends \yii\base\Component
         return
             ($request->getIsGet() || $request->getIsHead()) &&
             !$request->getIsCpRequest() &&
-            !SessionHelper::exists() &&
             $response instanceof \craft\web\Response &&
             $response->getIsOk();
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -211,11 +211,10 @@ class StaticCache extends \yii\base\Component
     private function addCacheHeadersToWebResponse(): void
     {
         $headers = Craft::$app->getResponse()->getHeaders();
-        $staticCacheDirectives = $this->staticCacheDirectives();
 
         $headers->setDefault(
             HeaderEnum::CDN_CACHE_CONTROL->value,
-            $staticCacheDirectives->implode(','),
+            $this->staticCacheDirectives()->implode(','),
         );
 
         // Capture and remove any existing headers, so we can prepare them

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -340,6 +340,16 @@ class StaticCache extends \yii\base\Component
 
     private function syncNativeCacheHeaders(): void
     {
+        $nativeHeaders = Collection::make(headers_list())
+            ->map(function(string $header) {
+                [$name, $value] = array_pad(explode(':', $header, 2), 2, '');
+
+                return [
+                    'name' => trim($name),
+                    'value' => trim($value),
+                ];
+            });
+
         foreach ([HeaderEnum::CDN_CACHE_CONTROL, HeaderEnum::CACHE_CONTROL] as $header) {
             $headers = Craft::$app->getResponse()->getHeaders();
             $name = $header->value;
@@ -348,18 +358,13 @@ class StaticCache extends \yii\base\Component
                 continue;
             }
 
-            $nativeHeader = Collection::make(headers_list())->first(fn(string $nativeHeader) => str_starts_with(
-                strtolower($nativeHeader),
-                strtolower("$name:"),
-            ));
+            $nativeHeader = $nativeHeaders->first(fn(array $nativeHeader) => strtolower($nativeHeader['name']) === strtolower($name));
 
             if (!$nativeHeader) {
                 continue;
             }
 
-            $value = trim(substr($nativeHeader, strlen($name) + 1));
-
-            $headers->set($name, $value);
+            $headers->set($name, $nativeHeader['value']);
         }
     }
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -341,29 +341,24 @@ class StaticCache extends \yii\base\Component
     private function syncNativeCacheHeaders(): void
     {
         foreach ([HeaderEnum::CDN_CACHE_CONTROL, HeaderEnum::CACHE_CONTROL] as $header) {
-            $this->syncNativeCacheHeader($header);
+            $headers = Craft::$app->getResponse()->getHeaders();
+            $name = $header->value;
+
+            if ($headers->has($name)) {
+                continue;
+            }
+
+            $nativeHeader = Collection::make(headers_list())->first(fn(string $nativeHeader) => str_starts_with(
+                strtolower($nativeHeader),
+                strtolower("$name:"),
+            ));
+
+            if (!$nativeHeader) {
+                continue;
+            }
+
+            $headers->set($name, trim(substr($nativeHeader, strlen($name) + 1)));
         }
-    }
-
-    private function syncNativeCacheHeader(HeaderEnum $header): void
-    {
-        $headers = Craft::$app->getResponse()->getHeaders();
-        $name = $header->value;
-
-        if ($headers->has($name)) {
-            return;
-        }
-
-        $nativeHeader = Collection::make(headers_list())->first(fn(string $nativeHeader) => str_starts_with(
-            strtolower($nativeHeader),
-            strtolower("$name:"),
-        ));
-
-        if (!$nativeHeader) {
-            return;
-        }
-
-        $headers->set($name, trim(substr($nativeHeader, strlen($name) + 1)));
     }
 
     private function prepareTags(string|StaticCacheTag ...$tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -308,13 +308,22 @@ class StaticCache extends \yii\base\Component
 
     private function staticCacheDirectives(): Collection
     {
-        $cdnCacheControlDirectives = $this->headerDirectives(HeaderEnum::CDN_CACHE_CONTROL->value);
+        $this->syncNativeCacheHeaders();
+        $headers = Craft::$app->getResponse()->getHeaders();
+
+        $cdnCacheControlDirectives = Collection::make($headers->get(
+            HeaderEnum::CDN_CACHE_CONTROL->value,
+            first: false,
+        ) ?? []);
 
         if ($cdnCacheControlDirectives->isNotEmpty()) {
             return $cdnCacheControlDirectives;
         }
 
-        $cacheControlDirectives = $this->headerDirectives(HeaderEnum::CACHE_CONTROL->value);
+        $cacheControlDirectives = Collection::make($headers->get(
+            HeaderEnum::CACHE_CONTROL->value,
+            first: false,
+        ) ?? []);
 
         if ($cacheControlDirectives->isNotEmpty()) {
             return $cacheControlDirectives;
@@ -330,21 +339,32 @@ class StaticCache extends \yii\base\Component
         ]);
     }
 
-    private function headerDirectives(string $name): Collection
+    private function syncNativeCacheHeaders(): void
+    {
+        foreach ([HeaderEnum::CDN_CACHE_CONTROL, HeaderEnum::CACHE_CONTROL] as $header) {
+            $this->syncNativeCacheHeader($header);
+        }
+    }
+
+    private function syncNativeCacheHeader(HeaderEnum $header): void
     {
         $headers = Craft::$app->getResponse()->getHeaders();
-        $directives = Collection::make($headers->get($name, first: false) ?? []);
+        $name = $header->value;
 
-        if ($directives->isNotEmpty()) {
-            return $directives;
+        if ($headers->has($name)) {
+            return;
         }
 
-        return Collection::make(headers_list())
-            ->filter(fn(string $header) => str_starts_with(
-                strtolower($header),
-                strtolower("$name:"),
-            ))
-            ->map(fn(string $header) => trim(substr($header, strlen($name) + 1)));
+        $nativeHeader = Collection::make(headers_list())->first(fn(string $nativeHeader) => str_starts_with(
+            strtolower($nativeHeader),
+            strtolower("$name:"),
+        ));
+
+        if (!$nativeHeader) {
+            return;
+        }
+
+        $headers->set($name, trim(substr($nativeHeader, strlen($name) + 1)));
     }
 
     private function prepareTags(string|StaticCacheTag ...$tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -213,10 +213,6 @@ class StaticCache extends \yii\base\Component
         $headers = Craft::$app->getResponse()->getHeaders();
         $staticCacheDirectives = $this->staticCacheDirectives();
 
-        if ($this->hasNoCacheDirective($staticCacheDirectives)) {
-            return;
-        }
-
         $headers->setDefault(
             HeaderEnum::CDN_CACHE_CONTROL->value,
             $staticCacheDirectives->implode(','),
@@ -339,11 +335,6 @@ class StaticCache extends \yii\base\Component
             "max-age=$this->cacheDuration",
             "stale-while-revalidate=$swrDuration",
         ]);
-    }
-
-    private function hasNoCacheDirective(Collection $directives): bool
-    {
-        return $directives->contains(fn(string $directive) => preg_match('/(?:^|,\s*)(no-cache|no-store)\b/i', $directive) === 1);
     }
 
     private function prepareTags(string|StaticCacheTag ...$tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -128,10 +128,6 @@ class StaticCache extends \yii\base\Component
             $this->cacheDuration = $duration;
         }
 
-        if ($this->hasNoCacheHeader()) {
-            return;
-        }
-
         $this->addCacheHeadersToWebResponse();
     }
 
@@ -214,28 +210,16 @@ class StaticCache extends \yii\base\Component
 
     private function addCacheHeadersToWebResponse(): void
     {
-        $this->cacheDuration = $this->cacheDuration ?? Module::getInstance()->getConfig()->staticCacheDuration;
         $headers = Craft::$app->getResponse()->getHeaders();
+        $staticCacheDirectives = $this->staticCacheDirectives();
 
-        $cacheControlDirectives = Collection::make($headers->get(
-            HeaderEnum::CACHE_CONTROL->value,
-            first: false,
-        ));
-
-        // Copy cache-control directives to the cdn-cache-control header
-        // @see https://developers.cloudflare.com/cache/concepts/cdn-cache-control/#header-precedence
-        $swrDuration = Module::getInstance()->getConfig()->staticCacheStaleWhileRevalidateDuration;
-        $cdnCacheControlDirectives = $cacheControlDirectives->isEmpty()
-            ? Collection::make([
-                'public',
-                "max-age=$this->cacheDuration",
-                "stale-while-revalidate=$swrDuration",
-            ])
-            : $cacheControlDirectives;
+        if ($this->hasNoCacheDirective($staticCacheDirectives)) {
+            return;
+        }
 
         $headers->setDefault(
             HeaderEnum::CDN_CACHE_CONTROL->value,
-            $cdnCacheControlDirectives->implode(','),
+            $staticCacheDirectives->implode(','),
         );
 
         // Capture and remove any existing headers, so we can prepare them
@@ -326,36 +310,40 @@ class StaticCache extends \yii\base\Component
             $response->getIsOk();
     }
 
-    private function hasNoCacheHeader(): bool
-    {
-        return Collection::make([
-            HeaderEnum::CACHE_CONTROL->value,
-            HeaderEnum::CDN_CACHE_CONTROL->value,
-        ])
-            ->flatMap(fn(string $headerName) => $this->cacheHeaderValues($headerName))
-            ->contains(fn(string $header) => preg_match('/(?:^|,\s*)(no-cache|no-store)\b/i', $header) === 1);
-    }
-
-    private function cacheHeaderValues(string $headerName): Collection
+    private function staticCacheDirectives(): Collection
     {
         $headers = Craft::$app->getResponse()->getHeaders();
-
-        $responseHeaders = Collection::make($headers->get(
-            $headerName,
+        $cdnCacheControlDirectives = Collection::make($headers->get(
+            HeaderEnum::CDN_CACHE_CONTROL->value,
             first: false,
         ) ?? []);
 
-        $nativeHeaders = Collection::make(headers_list())
-            ->filter(fn(string $header) => str_starts_with(
-                strtolower($header),
-                strtolower("$headerName:"),
-            ))
-            ->map(fn(string $header) => trim(substr(
-                $header,
-                strlen($headerName) + 1,
-            )));
+        if ($cdnCacheControlDirectives->isNotEmpty()) {
+            return $cdnCacheControlDirectives;
+        }
 
-        return $responseHeaders->merge($nativeHeaders);
+        $cacheControlDirectives = Collection::make($headers->get(
+            HeaderEnum::CACHE_CONTROL->value,
+            first: false,
+        ) ?? []);
+
+        if ($cacheControlDirectives->isNotEmpty()) {
+            return $cacheControlDirectives;
+        }
+
+        $this->cacheDuration = $this->cacheDuration ?? Module::getInstance()->getConfig()->staticCacheDuration;
+        $swrDuration = Module::getInstance()->getConfig()->staticCacheStaleWhileRevalidateDuration;
+
+        return Collection::make([
+            'public',
+            "max-age=$this->cacheDuration",
+            "stale-while-revalidate=$swrDuration",
+        ]);
+    }
+
+    private function hasNoCacheDirective(Collection $directives): bool
+    {
+        return $directives->contains(fn(string $directive) => preg_match('/(?:^|,\s*)(no-cache|no-store)\b/i', $directive) === 1);
     }
 
     private function prepareTags(string|StaticCacheTag ...$tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -328,26 +328,34 @@ class StaticCache extends \yii\base\Component
 
     private function hasNoCacheHeader(): bool
     {
+        return Collection::make([
+            HeaderEnum::CACHE_CONTROL->value,
+            HeaderEnum::CDN_CACHE_CONTROL->value,
+        ])
+            ->flatMap(fn(string $headerName) => $this->cacheHeaderValues($headerName))
+            ->contains(fn(string $header) => preg_match('/(?:^|,\s*)(no-cache|no-store)\b/i', $header) === 1);
+    }
+
+    private function cacheHeaderValues(string $headerName): Collection
+    {
         $headers = Craft::$app->getResponse()->getHeaders();
 
         $responseHeaders = Collection::make($headers->get(
-            HeaderEnum::CACHE_CONTROL->value,
+            $headerName,
             first: false,
         ) ?? []);
 
         $nativeHeaders = Collection::make(headers_list())
             ->filter(fn(string $header) => str_starts_with(
                 strtolower($header),
-                strtolower(HeaderEnum::CACHE_CONTROL->value . ':'),
+                strtolower("$headerName:"),
             ))
             ->map(fn(string $header) => trim(substr(
                 $header,
-                strlen(HeaderEnum::CACHE_CONTROL->value) + 1,
+                strlen($headerName) + 1,
             )));
 
-        return $responseHeaders
-            ->merge($nativeHeaders)
-            ->contains(fn(string $header) => preg_match('/(?:^|,\s*)(no-cache|no-store)\b/i', $header) === 1);
+        return $responseHeaders->merge($nativeHeaders);
     }
 
     private function prepareTags(string|StaticCacheTag ...$tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -357,7 +357,9 @@ class StaticCache extends \yii\base\Component
                 continue;
             }
 
-            $headers->set($name, trim(substr($nativeHeader, strlen($name) + 1)));
+            $value = trim(substr($nativeHeader, strlen($name) + 1));
+
+            $headers->set($name, $value);
         }
     }
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -128,6 +128,10 @@ class StaticCache extends \yii\base\Component
             $this->cacheDuration = $duration;
         }
 
+        if ($this->hasNoCacheHeader()) {
+            return;
+        }
+
         $this->addCacheHeadersToWebResponse();
     }
 
@@ -320,6 +324,30 @@ class StaticCache extends \yii\base\Component
             !$request->getIsCpRequest() &&
             $response instanceof \craft\web\Response &&
             $response->getIsOk();
+    }
+
+    private function hasNoCacheHeader(): bool
+    {
+        $headers = Craft::$app->getResponse()->getHeaders();
+
+        $responseHeaders = Collection::make($headers->get(
+            HeaderEnum::CACHE_CONTROL->value,
+            first: false,
+        ) ?? []);
+
+        $nativeHeaders = Collection::make(headers_list())
+            ->filter(fn(string $header) => str_starts_with(
+                strtolower($header),
+                strtolower(HeaderEnum::CACHE_CONTROL->value . ':'),
+            ))
+            ->map(fn(string $header) => trim(substr(
+                $header,
+                strlen(HeaderEnum::CACHE_CONTROL->value) + 1,
+            )));
+
+        return $responseHeaders
+            ->merge($nativeHeaders)
+            ->contains(fn(string $header) => preg_match('/(?:^|,\s*)(no-cache|no-store)\b/i', $header) === 1);
     }
 
     private function prepareTags(string|StaticCacheTag ...$tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -13,6 +13,7 @@ use craft\services\Elements;
 use craft\utilities\ClearCaches;
 use craft\web\UrlManager;
 use craft\web\View;
+use GuzzleHttp\Utils as GuzzleUtils;
 use Illuminate\Support\Collection;
 use League\Uri\Components\Path;
 use samdark\log\PsrMessage;
@@ -340,31 +341,23 @@ class StaticCache extends \yii\base\Component
 
     private function syncNativeCacheHeaders(): void
     {
-        $nativeHeaders = Collection::make(headers_list())
-            ->map(function(string $header) {
-                [$name, $value] = array_pad(explode(':', $header, 2), 2, '');
-
-                return [
-                    'name' => trim($name),
-                    'value' => trim($value),
-                ];
-            });
+        $headers = Craft::$app->getResponse()->getHeaders();
+        $nativeHeaders = Collection::make(GuzzleUtils::headersFromLines(headers_list()));
 
         foreach ([HeaderEnum::CDN_CACHE_CONTROL, HeaderEnum::CACHE_CONTROL] as $header) {
-            $headers = Craft::$app->getResponse()->getHeaders();
             $name = $header->value;
 
             if ($headers->has($name)) {
                 continue;
             }
 
-            $nativeHeader = $nativeHeaders->first(fn(array $nativeHeader) => strtolower($nativeHeader['name']) === strtolower($name));
+            $values = $nativeHeaders->first(fn(array $values, string $nativeName) => strtolower($nativeName) === strtolower($name));
 
-            if (!$nativeHeader) {
+            if (!$values) {
                 continue;
             }
 
-            $headers->set($name, $nativeHeader['value']);
+            $headers->set($name, $values);
         }
     }
 

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -76,12 +76,16 @@ class StaticCacheTest extends Unit
     {
         $staticCache = new StaticCache();
 
-        Craft::$app->getResponse()->getHeaders()->set(
-            HeaderEnum::CACHE_CONTROL->value,
-            'no-cache, no-store, must-revalidate',
-        );
+        foreach ([HeaderEnum::CACHE_CONTROL, HeaderEnum::CDN_CACHE_CONTROL] as $header) {
+            Craft::$app->getResponse()->getHeaders()->set(
+                $header->value,
+                'no-cache, no-store, must-revalidate',
+            );
 
-        $this->assertTrue($this->hasNoCacheHeader($staticCache));
+            $this->assertTrue($this->hasNoCacheHeader($staticCache));
+
+            Craft::$app->getResponse()->clear();
+        }
     }
 
     private function isCacheable(StaticCache $staticCache): bool

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -73,25 +73,6 @@ class StaticCacheTest extends Unit
         $this->assertFalse($this->isCacheable($staticCache));
     }
 
-    public function testNoCacheHeadersAreUsedForStaticCacheDirectives(): void
-    {
-        $staticCache = new StaticCache();
-
-        foreach ([HeaderEnum::CACHE_CONTROL, HeaderEnum::CDN_CACHE_CONTROL] as $header) {
-            Craft::$app->getResponse()->getHeaders()->set(
-                $header->value,
-                'no-cache, no-store, must-revalidate',
-            );
-
-            $this->assertSame(
-                ['no-cache, no-store, must-revalidate'],
-                $this->staticCacheDirectives($staticCache)->all(),
-            );
-
-            Craft::$app->getResponse()->clear();
-        }
-    }
-
     public function testStaticCacheDirectivesPreferCdnCacheControl(): void
     {
         $staticCache = new StaticCache();
@@ -126,5 +107,4 @@ class StaticCacheTest extends Unit
 
         return $method->invoke($staticCache);
     }
-
 }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -5,7 +5,6 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\StaticCache;
-use craft\helpers\Session as SessionHelper;
 use ReflectionMethod;
 
 class StaticCacheTest extends Unit
@@ -24,8 +23,6 @@ class StaticCacheTest extends Unit
         Craft::$app->getRequest()->setIsCpRequest(false);
         Craft::$app->getResponse()->clear();
         Craft::$app->getResponse()->setStatusCode(200);
-        Craft::$app->getSession()->setHasSessionId(false);
-        SessionHelper::reset();
 
         $this->requestMethod = $_SERVER['REQUEST_METHOD'] ?? null;
         $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -35,8 +32,6 @@ class StaticCacheTest extends Unit
     {
         Craft::$app->getRequest()->setIsCpRequest(null);
         Craft::$app->getResponse()->clear();
-        Craft::$app->getSession()->setHasSessionId(false);
-        SessionHelper::reset();
 
         if ($this->requestMethod === null) {
             unset($_SERVER['REQUEST_METHOD']);
@@ -52,15 +47,6 @@ class StaticCacheTest extends Unit
         $staticCache = new StaticCache();
 
         Craft::$app->getRequest()->setIsCpRequest(true);
-
-        $this->assertFalse($this->isCacheable($staticCache));
-    }
-
-    public function testSessionResponsesAreNotCacheable(): void
-    {
-        $staticCache = new StaticCache();
-
-        Craft::$app->getSession()->setHasSessionId(true);
 
         $this->assertFalse($this->isCacheable($staticCache));
     }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -73,7 +73,7 @@ class StaticCacheTest extends Unit
         $this->assertFalse($this->isCacheable($staticCache));
     }
 
-    public function testNoCacheResponsesDoNotAllowStaticCacheHeaders(): void
+    public function testNoCacheHeadersAreUsedForStaticCacheDirectives(): void
     {
         $staticCache = new StaticCache();
 
@@ -83,10 +83,10 @@ class StaticCacheTest extends Unit
                 'no-cache, no-store, must-revalidate',
             );
 
-            $this->assertTrue($this->hasNoCacheDirective(
-                $staticCache,
-                $this->staticCacheDirectives($staticCache),
-            ));
+            $this->assertSame(
+                ['no-cache, no-store, must-revalidate'],
+                $this->staticCacheDirectives($staticCache)->all(),
+            );
 
             Craft::$app->getResponse()->clear();
         }
@@ -127,11 +127,4 @@ class StaticCacheTest extends Unit
         return $method->invoke($staticCache);
     }
 
-    private function hasNoCacheDirective(StaticCache $staticCache, Collection $directives): bool
-    {
-        $method = new ReflectionMethod($staticCache, 'hasNoCacheDirective');
-        $method->setAccessible(true);
-
-        return $method->invoke($staticCache, $directives);
-    }
 }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -6,6 +6,7 @@ use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\HeaderEnum;
 use craft\cloud\StaticCache;
+use Illuminate\Support\Collection;
 use ReflectionMethod;
 
 class StaticCacheTest extends Unit
@@ -82,10 +83,32 @@ class StaticCacheTest extends Unit
                 'no-cache, no-store, must-revalidate',
             );
 
-            $this->assertTrue($this->hasNoCacheHeader($staticCache));
+            $this->assertTrue($this->hasNoCacheDirective(
+                $staticCache,
+                $this->staticCacheDirectives($staticCache),
+            ));
 
             Craft::$app->getResponse()->clear();
         }
+    }
+
+    public function testStaticCacheDirectivesPreferCdnCacheControl(): void
+    {
+        $staticCache = new StaticCache();
+
+        Craft::$app->getResponse()->getHeaders()->set(
+            HeaderEnum::CACHE_CONTROL->value,
+            'public,max-age=60',
+        );
+        Craft::$app->getResponse()->getHeaders()->set(
+            HeaderEnum::CDN_CACHE_CONTROL->value,
+            'no-store',
+        );
+
+        $this->assertSame(
+            ['no-store'],
+            $this->staticCacheDirectives($staticCache)->all(),
+        );
     }
 
     private function isCacheable(StaticCache $staticCache): bool
@@ -96,11 +119,19 @@ class StaticCacheTest extends Unit
         return $method->invoke($staticCache);
     }
 
-    private function hasNoCacheHeader(StaticCache $staticCache): bool
+    private function staticCacheDirectives(StaticCache $staticCache): Collection
     {
-        $method = new ReflectionMethod($staticCache, 'hasNoCacheHeader');
+        $method = new ReflectionMethod($staticCache, 'staticCacheDirectives');
         $method->setAccessible(true);
 
         return $method->invoke($staticCache);
+    }
+
+    private function hasNoCacheDirective(StaticCache $staticCache, Collection $directives): bool
+    {
+        $method = new ReflectionMethod($staticCache, 'hasNoCacheDirective');
+        $method->setAccessible(true);
+
+        return $method->invoke($staticCache, $directives);
     }
 }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -4,6 +4,7 @@ namespace craft\cloud\tests\unit;
 
 use Codeception\Test\Unit;
 use Craft;
+use craft\cloud\HeaderEnum;
 use craft\cloud\StaticCache;
 use ReflectionMethod;
 
@@ -71,9 +72,29 @@ class StaticCacheTest extends Unit
         $this->assertFalse($this->isCacheable($staticCache));
     }
 
+    public function testNoCacheResponsesDoNotAllowStaticCacheHeaders(): void
+    {
+        $staticCache = new StaticCache();
+
+        Craft::$app->getResponse()->getHeaders()->set(
+            HeaderEnum::CACHE_CONTROL->value,
+            'no-cache, no-store, must-revalidate',
+        );
+
+        $this->assertTrue($this->hasNoCacheHeader($staticCache));
+    }
+
     private function isCacheable(StaticCache $staticCache): bool
     {
         $method = new ReflectionMethod($staticCache, 'isCacheable');
+        $method->setAccessible(true);
+
+        return $method->invoke($staticCache);
+    }
+
+    private function hasNoCacheHeader(StaticCache $staticCache): bool
+    {
+        $method = new ReflectionMethod($staticCache, 'hasNoCacheHeader');
         $method->setAccessible(true);
 
         return $method->invoke($staticCache);


### PR DESCRIPTION
Avoids resolving the session component during app init by deriving static cache directives from response headers instead of checking for an active session.

Native PHP cache headers are synced into Yii first, so session/no-cache responses still flow through to CDN-Cache-Control without forcing bootstrap-time session resolution.