### PR TITLE
Normalize signed ESI URLs

### DIFF
--- a/src/signing/UrlSigner.php
+++ b/src/signing/UrlSigner.php
@@ -9,6 +9,10 @@ use HttpMessageSignatures\Exception\VerificationException;
 use HttpMessageSignatures\Url\UrlSigner as HttpUrlSigner;
 use HttpMessageSignatures\Url\UrlSigningConfig;
 use HttpMessageSignatures\Url\UrlVerifier as HttpUrlVerifier;
+use League\Uri\Components\Query;
+use League\Uri\Modifier;
+use League\Uri\UriString;
+use Throwable;
 
 class UrlSigner
 {
@@ -22,12 +26,29 @@ class UrlSigner
 
     public function sign(string $url): string
     {
-        return $this->createSigner()->sign($url);
+        return $this->createSigner()->sign($this->normalizeUrlForSigning($url));
     }
 
     public function verify(string $url): bool
     {
         try {
+            $normalizedUrl = $this->normalizeUrlForSigning($url);
+        } catch (Throwable $e) {
+            Craft::info([
+                'message' => 'Invalid URL signature',
+                'reason' => sprintf('URL could not be normalized: %s', $e->getMessage()),
+                'url' => $url,
+                'signatureParameter' => $this->signatureParameter,
+            ], __METHOD__);
+
+            return false;
+        }
+
+        try {
+            if ($url !== $normalizedUrl) {
+                throw new VerificationException('URL is not normalized.');
+            }
+
             return $this->createVerifier()->verify($url);
         } catch (VerificationException $e) {
             Craft::info([
@@ -39,6 +60,28 @@ class UrlSigner
 
             return false;
         }
+    }
+
+    /**
+     * Normalize query serialization before signing.
+     *
+     * Older Craft versions leave forward slashes unencoded in query values,
+     * e.g. `template=_includes/head`, and Yii query generation may encode
+     * spaces as `+`. The shared URL signer signs `@query`, then returns a
+     * League URI-serialized URL where slashes are encoded. Signing a normalized
+     * form keeps the signature tied to the exact URL we return, while parsing
+     * with form-data semantics preserves the values PHP will expose to action
+     * controllers.
+     *
+     * @see https://github.com/craftcms/cms/pull/19057
+     */
+    private function normalizeUrlForSigning(string $url): string
+    {
+        $query = Query::fromFormData(UriString::parse($url)['query']);
+
+        return Modifier::wrap($url)
+            ->withQuery($query->toRFC3986())
+            ->toString();
     }
 
     private function createSigner(): HttpUrlSigner

--- a/tests/unit/UrlSignerTest.php
+++ b/tests/unit/UrlSignerTest.php
@@ -54,6 +54,13 @@ class UrlSignerTest extends Unit
         $this->tester->assertFalse($this->urlSigner->verify($url));
     }
 
+    public function testVerifyReturnsFalseForMalformedUrl(): void
+    {
+        $url = 'https://exa mple.com/test?s=wrongsignature';
+
+        $this->tester->assertFalse($this->urlSigner->verify($url));
+    }
+
     public function testSignWithExistingQueryParameters()
     {
         $url = 'https://example.com/test?foo=bar&baz=qux';
@@ -63,6 +70,52 @@ class UrlSignerTest extends Unit
         $this->tester->assertStringContainsString('baz=qux', $signedUrl);
         $this->tester->assertStringContainsString('&s=', $signedUrl);
         $this->tester->assertTrue($this->urlSigner->verify($signedUrl));
+    }
+
+    public function testSignNormalizesQueryValuesBeforeSigning(): void
+    {
+        $url = 'https://example.com/actions/cloud/esi/render-template?template=_includes/head';
+        $signedUrl = $this->urlSigner->sign($url);
+
+        $this->tester->assertStringContainsString('template=_includes%2Fhead', $signedUrl);
+        $this->tester->assertTrue($this->urlSigner->verify($signedUrl));
+    }
+
+    public function testSignPreservesFormEncodedQueryValues(): void
+    {
+        $url = 'https://example.com/actions/cloud/esi/render-template?variables%5Btitle%5D=Hello+world';
+        $signedUrl = $this->urlSigner->sign($url);
+
+        $this->tester->assertStringContainsString('variables%5Btitle%5D=Hello%20world', $signedUrl);
+        $this->tester->assertStringNotContainsString('variables%5Btitle%5D=Hello%2Bworld', $signedUrl);
+        $this->tester->assertTrue($this->urlSigner->verify($signedUrl));
+    }
+
+    public function testVerifyRejectsNonCanonicalQueryValues(): void
+    {
+        $encodedUrl = 'https://example.com/actions/cloud/esi/render-template?template=_includes%2Fhead';
+        $signedUrl = $this->urlSigner->sign($encodedUrl);
+        $rawUrl = str_replace('template=_includes%2Fhead', 'template=_includes/head', $signedUrl);
+
+        $this->tester->assertFalse($this->urlSigner->verify($rawUrl));
+    }
+
+    public function testVerifyRejectsQueryValuesThatParseDifferently(): void
+    {
+        $encodedUrl = 'https://example.com/actions/cloud/esi/render-template?template=foo%2Bbar';
+        $signedUrl = $this->urlSigner->sign($encodedUrl);
+        $rawUrl = str_replace('template=foo%2Bbar', 'template=foo+bar', $signedUrl);
+
+        $this->tester->assertFalse($this->urlSigner->verify($rawUrl));
+    }
+
+    public function testVerifyRejectsAlternateFormEncodedQueryValues(): void
+    {
+        $encodedUrl = 'https://example.com/actions/cloud/esi/render-template?variables%5Btitle%5D=Hello%20world';
+        $signedUrl = $this->urlSigner->sign($encodedUrl);
+        $rawUrl = str_replace('variables%5Btitle%5D=Hello%20world', 'variables%5Btitle%5D=Hello+world', $signedUrl);
+
+        $this->tester->assertFalse($this->urlSigner->verify($rawUrl));
     }
 
     public function testSignReplacesExistingSignatureParameter()


### PR DESCRIPTION
Keeps ESI URL signatures stable when older Craft versions generate raw slashes in query values.

Cloud now signs the normalized URL it returns while rejecting alternate query serializations during verification.