### PR TITLE
Preserve uploaded asset dimensions

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -394,8 +394,14 @@ class AssetsController extends Controller
         try {
             $asset->size = $this->uploadedAssetSize($asset, $filename, $displayFilename);
             [$width, $height] = $this->uploadedImageDimensions($asset, $filename);
+            [$fallbackWidth, $fallbackHeight] = $this->uploadedRequestImageDimensions();
             $asset->width = $width;
             $asset->height = $height;
+
+            if ($asset->width === null || $asset->height === null) {
+                $asset->width = $asset->width ?? $fallbackWidth;
+                $asset->height = $asset->height ?? $fallbackHeight;
+            }
         } catch (Throwable $e) {
             $this->deleteUploadedAsset($asset, $filename);
             throw $e;
@@ -425,6 +431,14 @@ class AssetsController extends Controller
         return $fs instanceof Fs
             ? $fs->getImageDimensions($asset->getPath($filename)) ?? [null, null]
             : [null, null];
+    }
+
+    protected function uploadedRequestImageDimensions(): array
+    {
+        return [
+            (int)$this->request->getBodyParam('width') ?: null,
+            (int)$this->request->getBodyParam('height') ?: null,
+        ];
     }
 
     private function deleteUploadedAsset(Asset $asset, string $filename): void

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -540,14 +540,25 @@ abstract class Fs extends FlysystemFs
             }
         }
 
-        return null;
+        try {
+            $stream = $this->getFileStream($uriPath);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $this->getImageDimensionsFromStream($stream);
     }
 
     private function getImageDimensionsFromRange(string $uriPath, int $bytes): ?array
     {
         $stream = $this->getFileStreamRange($uriPath, 0, $bytes - 1);
 
-        if ($stream === null) {
+        return $this->getImageDimensionsFromStream($stream);
+    }
+
+    private function getImageDimensionsFromStream($stream): ?array
+    {
+        if (!is_resource($stream)) {
             return null;
         }
 

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -113,6 +113,19 @@ class AssetsControllerTest extends Unit
         $this->assertSame(3, $fs->readCount);
     }
 
+    public function testUploadedImageDimensionsFallsBackToFullStream(): void
+    {
+        $fs = new HeaderTestFs();
+        $fs->headers = array_fill(0, 4, "\xFF\xD8" . "\xFF\xE1" . pack('n', 4) . 'xx');
+        $fs->streamHeader = "\xFF\xD8"
+            . "\xFF\xE1" . pack('n', 4) . 'xx'
+            . "\xFF\xC0" . pack('n', 17) . "\x08" . pack('n', 3024) . pack('n', 4032) . str_repeat("\0", 10);
+
+        $this->assertSame([4032, 3024], $fs->getImageDimensions('upload.jpeg'));
+        $this->assertSame(4, $fs->readCount);
+        $this->assertSame(1, $fs->streamReadCount);
+    }
+
     private function invokeVolumeSubpath(Volume $volume): string
     {
         $controller = new AssetsController('cloud-assets', Craft::$app);
@@ -160,6 +173,8 @@ class HeaderTestFs extends Fs
     public string $header;
     public array $headers = [];
     public int $readCount = 0;
+    public ?string $streamHeader = null;
+    public int $streamReadCount = 0;
 
     public static function displayName(): string
     {
@@ -177,6 +192,22 @@ class HeaderTestFs extends Fs
         }
 
         fwrite($stream, $this->headers[$this->readCount - 1] ?? $this->header);
+        rewind($stream);
+
+        return $stream;
+    }
+
+    public function getFileStream(string $uriPath)
+    {
+        $this->streamReadCount++;
+
+        $stream = fopen('php://temp', 'r+');
+
+        if ($stream === false) {
+            return null;
+        }
+
+        fwrite($stream, $this->streamHeader ?? $this->header);
         rewind($stream);
 
         return $stream;

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -61,6 +61,21 @@ class AssetsControllerTest extends Unit
         $this->assertSame(1, $fs->readCount);
     }
 
+    public function testUploadedAssetMetadataFallsBackToRequestDimensions(): void
+    {
+        $controller = new SizeTestAssetsController('cloud-assets', Craft::$app);
+        $controller->requestImageDimensions = [2496, 2496];
+        $asset = new TestAsset(new TestVolume(123, new MissingDimensionsTestFs()));
+        $asset->setFilename('upload.png');
+        $asset->kind = Asset::KIND_IMAGE;
+
+        $controller->setUploadedAssetMetadataForTest($asset, 'upload.png');
+
+        $this->assertSame(123, $asset->size);
+        $this->assertSame(2496, $asset->getWidth());
+        $this->assertSame(2496, $asset->getHeight());
+    }
+
     public function testUploadedAssetMetadataDeletesUploadedObjectOnValidationFailure(): void
     {
         $maxUploadSize = Craft::$app->getConfig()->getGeneral()->maxUploadFileSize;
@@ -110,9 +125,16 @@ class AssetsControllerTest extends Unit
 
 class SizeTestAssetsController extends AssetsController
 {
+    public array $requestImageDimensions = [null, null];
+
     public function setUploadedAssetMetadataForTest(Asset $asset, string $filename, ?string $displayFilename = null): void
     {
         $this->setUploadedAssetMetadata($asset, $filename, $displayFilename);
+    }
+
+    protected function uploadedRequestImageDimensions(): array
+    {
+        return $this->requestImageDimensions;
     }
 }
 
@@ -158,6 +180,14 @@ class HeaderTestFs extends Fs
         rewind($stream);
 
         return $stream;
+    }
+}
+
+class MissingDimensionsTestFs extends HeaderTestFs
+{
+    public function getImageDimensions(string $uriPath): ?array
+    {
+        return null;
     }
 }
 


### PR DESCRIPTION
Makes Cloud image dimension detection more reliable for direct replacements and reindexing by falling back from bounded range reads to full source-object inspection. Browser-provided dimensions are only used as a final fallback for browser uploads.