### PR TITLE
Bound image dimension reads

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -394,14 +394,8 @@ class AssetsController extends Controller
         try {
             $asset->size = $this->uploadedAssetSize($asset, $filename, $displayFilename);
             [$width, $height] = $this->uploadedImageDimensions($asset, $filename);
-            [$fallbackWidth, $fallbackHeight] = $this->uploadedRequestImageDimensions();
             $asset->width = $width;
             $asset->height = $height;
-
-            if ($asset->width === null || $asset->height === null) {
-                $asset->width = $asset->width ?? $fallbackWidth;
-                $asset->height = $asset->height ?? $fallbackHeight;
-            }
         } catch (Throwable $e) {
             $this->deleteUploadedAsset($asset, $filename);
             throw $e;
@@ -431,14 +425,6 @@ class AssetsController extends Controller
         return $fs instanceof Fs
             ? $fs->getImageDimensions($asset->getPath($filename)) ?? [null, null]
             : [null, null];
-    }
-
-    protected function uploadedRequestImageDimensions(): array
-    {
-        return [
-            (int)$this->request->getBodyParam('width') ?: null,
-            (int)$this->request->getBodyParam('height') ?: null,
-        ];
     }
 
     private function deleteUploadedAsset(Asset $asset, string $filename): void

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -540,13 +540,7 @@ abstract class Fs extends FlysystemFs
             }
         }
 
-        try {
-            $stream = $this->getFileStream($uriPath);
-        } catch (Throwable) {
-            return null;
-        }
-
-        return $this->getImageDimensionsFromStream($stream);
+        return null;
     }
 
     private function getImageDimensionsFromRange(string $uriPath, int $bytes): ?array

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -540,6 +540,11 @@ abstract class Fs extends FlysystemFs
             }
         }
 
+        Craft::warning(
+            "Unable to determine image dimensions for \"{$uriPath}\" within the " . self::IMAGE_DIMENSION_MAX_BYTES . ' byte read limit.',
+            __METHOD__,
+        );
+
         return null;
     }
 

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -61,19 +61,18 @@ class AssetsControllerTest extends Unit
         $this->assertSame(1, $fs->readCount);
     }
 
-    public function testUploadedAssetMetadataFallsBackToRequestDimensions(): void
+    public function testUploadedAssetMetadataLeavesUnreadableDimensionsNull(): void
     {
         $controller = new SizeTestAssetsController('cloud-assets', Craft::$app);
-        $controller->requestImageDimensions = [2496, 2496];
-        $asset = new TestAsset(new TestVolume(123, new MissingDimensionsTestFs()));
+        $asset = new TestAsset(new TestVolume(123, new NullDimensionsTestFs()));
         $asset->setFilename('upload.png');
         $asset->kind = Asset::KIND_IMAGE;
 
         $controller->setUploadedAssetMetadataForTest($asset, 'upload.png');
 
         $this->assertSame(123, $asset->size);
-        $this->assertSame(2496, $asset->getWidth());
-        $this->assertSame(2496, $asset->getHeight());
+        $this->assertNull($asset->getWidth());
+        $this->assertNull($asset->getHeight());
     }
 
     public function testUploadedAssetMetadataDeletesUploadedObjectOnValidationFailure(): void
@@ -113,17 +112,17 @@ class AssetsControllerTest extends Unit
         $this->assertSame(3, $fs->readCount);
     }
 
-    public function testUploadedImageDimensionsFallsBackToFullStream(): void
+    public function testUploadedImageDimensionsStopAfterBoundedRanges(): void
     {
-        $fs = new HeaderTestFs();
+        $fs = new FullStreamHeaderTestFs();
         $fs->headers = array_fill(0, 4, "\xFF\xD8" . "\xFF\xE1" . pack('n', 4) . 'xx');
         $fs->streamHeader = "\xFF\xD8"
             . "\xFF\xE1" . pack('n', 4) . 'xx'
             . "\xFF\xC0" . pack('n', 17) . "\x08" . pack('n', 3024) . pack('n', 4032) . str_repeat("\0", 10);
 
-        $this->assertSame([4032, 3024], $fs->getImageDimensions('upload.jpeg'));
+        $this->assertNull($fs->getImageDimensions('upload.jpeg'));
         $this->assertSame(4, $fs->readCount);
-        $this->assertSame(1, $fs->streamReadCount);
+        $this->assertSame(0, $fs->streamReadCount);
     }
 
     private function invokeVolumeSubpath(Volume $volume): string
@@ -138,16 +137,9 @@ class AssetsControllerTest extends Unit
 
 class SizeTestAssetsController extends AssetsController
 {
-    public array $requestImageDimensions = [null, null];
-
     public function setUploadedAssetMetadataForTest(Asset $asset, string $filename, ?string $displayFilename = null): void
     {
         $this->setUploadedAssetMetadata($asset, $filename, $displayFilename);
-    }
-
-    protected function uploadedRequestImageDimensions(): array
-    {
-        return $this->requestImageDimensions;
     }
 }
 
@@ -173,8 +165,6 @@ class HeaderTestFs extends Fs
     public string $header;
     public array $headers = [];
     public int $readCount = 0;
-    public ?string $streamHeader = null;
-    public int $streamReadCount = 0;
 
     public static function displayName(): string
     {
@@ -196,6 +186,12 @@ class HeaderTestFs extends Fs
 
         return $stream;
     }
+}
+
+class FullStreamHeaderTestFs extends HeaderTestFs
+{
+    public ?string $streamHeader = null;
+    public int $streamReadCount = 0;
 
     public function getFileStream(string $uriPath)
     {
@@ -214,7 +210,7 @@ class HeaderTestFs extends Fs
     }
 }
 
-class MissingDimensionsTestFs extends HeaderTestFs
+class NullDimensionsTestFs extends HeaderTestFs
 {
     public function getImageDimensions(string $uriPath): ?array
     {


### PR DESCRIPTION
Keeps Cloud upload metadata processing from falling back to unbounded source-object reads or browser-provided dimensions when server-side image probing cannot determine dimensions.