### PR TITLE
Support PDF transform URLs

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -105,15 +105,7 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 Asset::class,
                 Asset::EVENT_BEFORE_GENERATE_TRANSFORM,
                 function(GenerateTransformEvent $event) {
-                    if (!$event->transform) {
-                        return;
-                    }
-
-                    // Keep the image editor preview in native source-pixel coordinates.
-                    if (
-                        Craft::$app instanceof WebApplication &&
-                        Craft::$app->getRequest()->getActionSegments() === ['assets', 'edit-image']
-                    ) {
+                    if (!$this->shouldUseAssetCdnTransform($event)) {
                         return;
                     }
 
@@ -133,11 +125,12 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 Asset::class,
                 Asset::EVENT_BEFORE_DEFINE_URL,
                 function(DefineAssetUrlEvent $event) {
-                    if ($event->url !== null || $event->asset->kind !== Asset::KIND_PDF) {
-                        return;
-                    }
-
-                    if (!$event->transform) {
+                    if (
+                        $event->url !== null ||
+                        $event->asset->kind !== Asset::KIND_PDF ||
+                        !$event->transform ||
+                        !$this->isRemoteCloudAsset($event->asset)
+                    ) {
                         return;
                     }
 
@@ -157,7 +150,11 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 AssetsService::class,
                 AssetsService::EVENT_DEFINE_THUMB_URL,
                 function(DefineAssetThumbUrlEvent $event) {
-                    if ($event->url !== null || $event->asset->kind !== Asset::KIND_PDF) {
+                    if (
+                        $event->url !== null ||
+                        $event->asset->kind !== Asset::KIND_PDF ||
+                        !$this->isRemoteCloudAsset($event->asset)
+                    ) {
                         return;
                     }
 
@@ -181,6 +178,27 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 $app->getView()->registerAssetBundle(UploaderAsset::class);
             }
         }
+    }
+
+    protected function shouldUseAssetCdnTransform(GenerateTransformEvent $event): bool
+    {
+        if (!$event->transform || !$this->isRemoteCloudAsset($event->asset)) {
+            return false;
+        }
+
+        if (!(Craft::$app instanceof WebApplication)) {
+            return true;
+        }
+
+        // The image editor reads raw source pixels for save/crop math.
+        return Craft::$app->getRequest()->getActionSegments() !== ['assets', 'edit-image'];
+    }
+
+    private function isRemoteCloudAsset(Asset $asset): bool
+    {
+        $assetFs = $asset->getVolume()->getFs();
+
+        return $assetFs instanceof AssetsFs && !$assetFs->useLocalFs;
     }
 
     public function getConfig(): Config

--- a/src/Module.php
+++ b/src/Module.php
@@ -105,7 +105,15 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 Asset::class,
                 Asset::EVENT_BEFORE_GENERATE_TRANSFORM,
                 function(GenerateTransformEvent $event) {
-                    if (!$this->shouldUseAssetCdnTransform($event)) {
+                    if (!$event->transform) {
+                        return;
+                    }
+
+                    // Keep the image editor preview in native source-pixel coordinates.
+                    if (
+                        Craft::$app instanceof WebApplication &&
+                        Craft::$app->getRequest()->getActionSegments() === ['assets', 'edit-image']
+                    ) {
                         return;
                     }
 
@@ -116,7 +124,7 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                             true,
                         );
                     } catch (NotSupportedException) {
-                        Craft::info("Transforms not supported for {$event->asset->getPath()}", __METHOD__);
+                        return;
                     }
                 }
             );
@@ -173,23 +181,6 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 $app->getView()->registerAssetBundle(UploaderAsset::class);
             }
         }
-    }
-
-    protected function shouldUseAssetCdnTransform(GenerateTransformEvent $event): bool
-    {
-        $assetFs = $event->asset?->fs;
-
-        if (!$event->transform || !$assetFs instanceof AssetsFs || $assetFs->useLocalFs) {
-            return false;
-        }
-
-        if (!(Craft::$app instanceof WebApplication)) {
-            return true;
-        }
-
-        // The image editor reads raw source pixels for save/crop math, so keep
-        // its preview in the same coordinate space as the original asset.
-        return Craft::$app->getRequest()->getActionSegments() !== ['assets', 'edit-image'];
     }
 
     public function getConfig(): Config

--- a/src/Module.php
+++ b/src/Module.php
@@ -133,10 +133,17 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                         return;
                     }
 
+                    $transformer = new ImageTransformer();
+                    $imageTransform = $transformer->normalizeTransform($event->transform);
+
+                    if (!$imageTransform) {
+                        return;
+                    }
+
                     try {
-                        $event->url = (new ImageTransformer())->getTransformUrl(
+                        $event->url = $transformer->getTransformUrl(
                             $event->asset,
-                            $event->transform,
+                            $imageTransform,
                             true,
                         );
                     } catch (NotSupportedException) {

--- a/src/Module.php
+++ b/src/Module.php
@@ -133,17 +133,10 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                         return;
                     }
 
-                    $transformer = new ImageTransformer();
-                    $imageTransform = $transformer->normalizeTransform($event->transform);
-
-                    if (!$imageTransform) {
-                        return;
-                    }
-
                     try {
-                        $event->url = $transformer->getTransformUrl(
+                        $event->url = (new ImageTransformer())->getTransformUrl(
                             $event->asset,
-                            $imageTransform,
+                            $event->transform,
                             true,
                         );
                     } catch (NotSupportedException) {
@@ -184,7 +177,9 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
 
     protected function shouldUseAssetCdnTransform(GenerateTransformEvent $event): bool
     {
-        if (!$event->transform || !$event->asset?->fs instanceof AssetsFs) {
+        $assetFs = $event->asset?->fs;
+
+        if (!$event->transform || !$assetFs instanceof AssetsFs || $assetFs->useLocalFs) {
             return false;
         }
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -125,11 +125,23 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 Asset::class,
                 Asset::EVENT_BEFORE_DEFINE_URL,
                 function(DefineAssetUrlEvent $event) {
-                    if ($event->url !== null) {
+                    if ($event->url !== null || $event->asset->kind !== Asset::KIND_PDF) {
                         return;
                     }
 
-                    $event->url = (new ImageTransformer())->getPdfTransformUrl($event->asset, $event->transform);
+                    if (!$event->transform) {
+                        return;
+                    }
+
+                    try {
+                        $event->url = (new ImageTransformer())->getTransformUrl(
+                            $event->asset,
+                            $event->transform,
+                            true,
+                        );
+                    } catch (NotSupportedException) {
+                        return;
+                    }
                 }
             );
 
@@ -137,11 +149,23 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 AssetsService::class,
                 AssetsService::EVENT_DEFINE_THUMB_URL,
                 function(DefineAssetThumbUrlEvent $event) {
-                    if ($event->url !== null) {
+                    if ($event->url !== null || $event->asset->kind !== Asset::KIND_PDF) {
                         return;
                     }
 
-                    $event->url = (new ImageTransformer())->getPdfThumbUrl($event->asset, $event->width, $event->height);
+                    try {
+                        $event->url = (new ImageTransformer())->getTransformUrl(
+                            $event->asset,
+                            new CraftImageTransform([
+                                'width' => $event->width,
+                                'height' => $event->height,
+                                'mode' => 'crop',
+                            ]),
+                            true,
+                        );
+                    } catch (NotSupportedException) {
+                        return;
+                    }
                 }
             );
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -15,6 +15,8 @@ use craft\cloud\web\assets\uploader\UploaderAsset;
 use craft\cloud\web\ResponseEventHandler;
 use craft\console\Application as ConsoleApplication;
 use craft\elements\Asset;
+use craft\events\DefineAssetThumbUrlEvent;
+use craft\events\DefineAssetUrlEvent;
 use craft\events\DefineBehaviorsEvent;
 use craft\events\DefineRulesEvent;
 use craft\events\GenerateTransformEvent;
@@ -24,6 +26,7 @@ use craft\helpers\App;
 use craft\helpers\ConfigHelper;
 use craft\log\MonologTarget;
 use craft\models\ImageTransform as CraftImageTransform;
+use craft\services\Assets as AssetsService;
 use craft\services\Fs as FsService;
 use craft\services\ImageTransforms;
 use craft\web\Application as WebApplication;
@@ -115,6 +118,30 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                     } catch (NotSupportedException) {
                         Craft::info("Transforms not supported for {$event->asset->getPath()}", __METHOD__);
                     }
+                }
+            );
+
+            Event::on(
+                Asset::class,
+                Asset::EVENT_BEFORE_DEFINE_URL,
+                function(DefineAssetUrlEvent $event) {
+                    if ($event->url !== null) {
+                        return;
+                    }
+
+                    $event->url = (new ImageTransformer())->getPdfTransformUrl($event->asset, $event->transform);
+                }
+            );
+
+            Event::on(
+                AssetsService::class,
+                AssetsService::EVENT_DEFINE_THUMB_URL,
+                function(DefineAssetThumbUrlEvent $event) {
+                    if ($event->url !== null) {
+                        return;
+                    }
+
+                    $event->url = (new ImageTransformer())->getPdfThumbUrl($event->asset, $event->width, $event->height);
                 }
             );
 

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -27,8 +27,20 @@ class ImageTransformer extends Component implements ImageTransformerInterface
     // Source asset extensions Cloudflare Images can accept for transformations.
     public const SUPPORTED_IMAGE_FORMATS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif', 'heic'];
 
-    public function getTransformUrl(Asset $asset, ImageTransform $imageTransform, bool $immediately): string
+    public function getTransformUrl(Asset $asset, mixed $imageTransform, bool $immediately): string
     {
+        if (!$imageTransform instanceof ImageTransform) {
+            $imageTransform = $this->normalizeTransform($imageTransform);
+        }
+
+        if (!$imageTransform instanceof ImageTransform) {
+            throw new NotSupportedException('Invalid image transform.');
+        }
+
+        if ($asset->kind === Asset::KIND_PDF) {
+            return $this->getPdfTransformUrl($asset, $imageTransform);
+        }
+
         $mimeType = $asset->getMimeType();
 
         if ($mimeType === 'image/gif' && !Craft::$app->getConfig()->getGeneral()->transformGifs) {
@@ -49,22 +61,12 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         return Module::getInstance()->getUrlSigner()->sign((string) $uri);
     }
 
-    public function getPdfTransformUrl(Asset $asset, mixed $transform): ?string
+    private function getPdfTransformUrl(Asset $asset, ImageTransform $imageTransform): string
     {
-        if ($asset->kind !== Asset::KIND_PDF) {
-            return null;
-        }
-
         $assetFs = $this->getAssetCdnFs($asset);
 
         if (!$assetFs) {
-            return null;
-        }
-
-        $imageTransform = $this->normalizeTransform($transform);
-
-        if (!$imageTransform) {
-            return null;
+            throw new NotSupportedException('PDF transforms are only supported for Cloud assets.');
         }
 
         $options = $this->getTransformOptions($imageTransform);
@@ -76,15 +78,6 @@ class ImageTransformer extends Component implements ImageTransformerInterface
             ->unwrap();
 
         return Module::getInstance()->getUrlSigner()->sign((string) $uri);
-    }
-
-    public function getPdfThumbUrl(Asset $asset, int $width, int $height): ?string
-    {
-        return $this->getPdfTransformUrl($asset, new ImageTransform([
-            'width' => $width,
-            'height' => $height,
-            'mode' => 'crop',
-        ]));
     }
 
     public function invalidateAssetTransforms(Asset $asset): void

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -27,16 +27,8 @@ class ImageTransformer extends Component implements ImageTransformerInterface
     // Source asset extensions Cloudflare Images can accept for transformations.
     public const SUPPORTED_IMAGE_FORMATS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif', 'heic'];
 
-    public function getTransformUrl(Asset $asset, mixed $imageTransform, bool $immediately): string
+    public function getTransformUrl(Asset $asset, ImageTransform $imageTransform, bool $immediately): string
     {
-        if (!$imageTransform instanceof ImageTransform) {
-            $imageTransform = $this->normalizeTransform($imageTransform);
-        }
-
-        if (!$imageTransform instanceof ImageTransform) {
-            throw new NotSupportedException('Invalid image transform.');
-        }
-
         $behavior = $imageTransform->getBehavior('cloud');
 
         if (!$behavior instanceof ImageTransformBehavior) {
@@ -100,7 +92,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         return $asset->getFocalPoint();
     }
 
-    private function normalizeTransform(mixed $transform): ?ImageTransform
+    public function normalizeTransform(mixed $transform): ?ImageTransform
     {
         if (is_array($transform)) {
             foreach (['width', 'height'] as $attribute) {

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -27,52 +27,48 @@ class ImageTransformer extends Component implements ImageTransformerInterface
     // Source asset extensions Cloudflare Images can accept for transformations.
     public const SUPPORTED_IMAGE_FORMATS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif', 'heic'];
 
-    public function getTransformUrl(Asset $asset, ImageTransform $imageTransform, bool $immediately): string
+    public function getTransformUrl(Asset $asset, mixed $transform, bool $immediately): string
     {
+        $imageTransform = $this->normalizeTransform($transform);
+
+        if (!$imageTransform) {
+            throw new NotSupportedException('Invalid image transform.');
+        }
+
+        $assetFs = $asset->getVolume()->getFs();
+
+        if (!$assetFs instanceof AssetsFs || $assetFs->useLocalFs) {
+            throw new NotSupportedException('Cloud transforms are only supported for Cloud assets.');
+        }
+
         $behavior = $imageTransform->getBehavior('cloud');
 
         if (!$behavior instanceof ImageTransformBehavior) {
             throw new \RuntimeException('Cloud image transform behavior is not attached.');
         }
 
-        if ($asset->kind === Asset::KIND_PDF) {
-            $assetFs = $this->getAssetCdnFs($asset);
+        if ($asset->kind !== Asset::KIND_PDF) {
+            $mimeType = $asset->getMimeType();
 
-            if (!$assetFs) {
-                throw new NotSupportedException('PDF transforms are only supported for Cloud assets.');
+            if ($mimeType === 'image/gif' && !Craft::$app->getConfig()->getGeneral()->transformGifs) {
+                throw new NotSupportedException('GIF files shouldn’t be transformed.');
             }
 
-            return $this->getPdfTransformUrl($asset, $assetFs, $behavior);
+            if ($mimeType === 'image/svg+xml' && !Craft::$app->getConfig()->getGeneral()->transformSvgs) {
+                throw new NotSupportedException('SVG files shouldn’t be transformed.');
+            }
         }
 
-        $mimeType = $asset->getMimeType();
+        $options = $behavior->toOptions($this->applyAssetFocalPointGravity($asset, $imageTransform));
 
-        if ($mimeType === 'image/gif' && !Craft::$app->getConfig()->getGeneral()->transformGifs) {
-            throw new NotSupportedException('GIF files shouldn’t be transformed.');
+        if ($asset->kind === Asset::KIND_PDF) {
+            $options['format'] ??= 'auto';
         }
 
-        if ($mimeType === 'image/svg+xml' && !Craft::$app->getConfig()->getGeneral()->transformSvgs) {
-            throw new NotSupportedException('SVG files shouldn’t be transformed.');
-        }
-
-        $gravity = $this->applyAssetFocalPointGravity($asset, $imageTransform);
-
-        $query = Query::fromVariable($behavior->toOptions($gravity));
-        $uri = Modifier::wrap($this->getAssetUri($asset))
-            ->mergeQuery($query)
-            ->unwrap();
-
-        return Module::getInstance()->getUrlSigner()->sign((string) $uri);
-    }
-
-    private function getPdfTransformUrl(Asset $asset, AssetsFs $assetFs, ImageTransformBehavior $behavior): string
-    {
-        $options = $behavior->toOptions();
-        $options['format'] ??= 'auto';
-
-        $query = Query::fromVariable($options);
-        $uri = Modifier::wrap($this->getAssetUri($asset, $assetFs))
-            ->mergeQuery($query)
+        $uri = Modifier::wrap($this->createBaseUri($asset))
+            ->mergeQuery(Query::fromVariable($options))
+            ->removeQueryParameters('v')
+            ->removeEmptyQueryPairs()
             ->unwrap();
 
         return Module::getInstance()->getUrlSigner()->sign((string) $uri);
@@ -92,7 +88,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         return $asset->getFocalPoint();
     }
 
-    public function normalizeTransform(mixed $transform): ?ImageTransform
+    private function normalizeTransform(mixed $transform): ?ImageTransform
     {
         if (is_array($transform)) {
             foreach (['width', 'height'] as $attribute) {
@@ -105,42 +101,18 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         return ImageTransformsHelper::normalizeTransform($transform);
     }
 
-    private function getAssetUri(Asset $asset, ?AssetsFs $assetFs = null): Uri
+    private function createBaseUri(Asset $asset): Uri
     {
-        $assetFs ??= $this->getAssetCdnFs($asset);
-
         if (version_compare(Craft::$app->version, '5.0', '>=')) {
             // @phpstan-ignore argument.type, arguments.count (Craft 5 compatibility)
             $url = Assets::generateUrl($asset);
         } else {
-            $transformFs = $asset->getVolume()->getTransformFs();
+            $fs = $asset->getVolume()->getTransformFs();
 
             // @phpstan-ignore argument.type, arguments.count (Craft 4 compatibility)
-            $url = Assets::generateUrl($transformFs, $asset);
+            $url = Assets::generateUrl($fs, $asset);
         }
 
-        $uri = Uri::new(Html::encodeSpaces($url));
-
-        if (!$assetFs) {
-            return $uri;
-        }
-
-        // Craft's asset revision query isn't needed for Cloud transforms,
-        // regardless of the revAssetUrls config setting.
-        return Uri::new((string) Modifier::wrap($uri)
-            ->removeQueryParameters('v')
-            ->removeEmptyQueryPairs()
-            ->unwrap());
-    }
-
-    private function getAssetCdnFs(Asset $asset): ?AssetsFs
-    {
-        $assetFs = $asset->getVolume()->getFs();
-
-        if (!$assetFs instanceof AssetsFs || $assetFs->useLocalFs) {
-            return null;
-        }
-
-        return $assetFs;
+        return Uri::new(Html::encodeSpaces($url));
     }
 }

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -37,8 +37,14 @@ class ImageTransformer extends Component implements ImageTransformerInterface
             throw new NotSupportedException('Invalid image transform.');
         }
 
+        $behavior = $imageTransform->getBehavior('cloud');
+
+        if (!$behavior instanceof ImageTransformBehavior) {
+            throw new \RuntimeException('Cloud image transform behavior is not attached.');
+        }
+
         if ($asset->kind === Asset::KIND_PDF) {
-            return $this->getPdfTransformUrl($asset, $imageTransform);
+            return $this->getPdfTransformUrl($asset, $behavior);
         }
 
         $mimeType = $asset->getMimeType();
@@ -53,7 +59,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
 
         $gravity = $this->applyAssetFocalPointGravity($asset, $imageTransform);
 
-        $query = Query::fromVariable($this->getTransformOptions($imageTransform, $gravity));
+        $query = Query::fromVariable($behavior->toOptions($gravity));
         $uri = Modifier::wrap($this->getAssetUri($asset))
             ->mergeQuery($query)
             ->unwrap();
@@ -61,7 +67,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         return Module::getInstance()->getUrlSigner()->sign((string) $uri);
     }
 
-    private function getPdfTransformUrl(Asset $asset, ImageTransform $imageTransform): string
+    private function getPdfTransformUrl(Asset $asset, ImageTransformBehavior $behavior): string
     {
         $assetFs = $this->getAssetCdnFs($asset);
 
@@ -69,7 +75,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
             throw new NotSupportedException('PDF transforms are only supported for Cloud assets.');
         }
 
-        $options = $this->getTransformOptions($imageTransform);
+        $options = $behavior->toOptions();
         $options['format'] ??= 'auto';
 
         $query = Query::fromVariable($options);
@@ -92,17 +98,6 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         }
 
         return $asset->getFocalPoint();
-    }
-
-    private function getTransformOptions(ImageTransform $imageTransform, array|string|null $gravity = null): array
-    {
-        $behavior = $imageTransform->getBehavior('cloud');
-
-        if (!$behavior instanceof ImageTransformBehavior) {
-            throw new \RuntimeException('Cloud image transform behavior is not attached.');
-        }
-
-        return $behavior->toOptions($gravity);
     }
 
     private function normalizeTransform(mixed $transform): ?ImageTransform

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -36,7 +36,13 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         }
 
         if ($asset->kind === Asset::KIND_PDF) {
-            return $this->getPdfTransformUrl($asset, $behavior);
+            $assetFs = $this->getAssetCdnFs($asset);
+
+            if (!$assetFs) {
+                throw new NotSupportedException('PDF transforms are only supported for Cloud assets.');
+            }
+
+            return $this->getPdfTransformUrl($asset, $assetFs, $behavior);
         }
 
         $mimeType = $asset->getMimeType();
@@ -59,14 +65,8 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         return Module::getInstance()->getUrlSigner()->sign((string) $uri);
     }
 
-    private function getPdfTransformUrl(Asset $asset, ImageTransformBehavior $behavior): string
+    private function getPdfTransformUrl(Asset $asset, AssetsFs $assetFs, ImageTransformBehavior $behavior): string
     {
-        $assetFs = $this->getAssetCdnFs($asset);
-
-        if (!$assetFs) {
-            throw new NotSupportedException('PDF transforms are only supported for Cloud assets.');
-        }
-
         $options = $behavior->toOptions();
         $options['format'] ??= 'auto';
 

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -10,6 +10,7 @@ use craft\cloud\Module;
 use craft\elements\Asset;
 use craft\helpers\Assets;
 use craft\helpers\Html;
+use craft\helpers\ImageTransforms as ImageTransformsHelper;
 use craft\models\ImageTransform;
 use League\Uri\Components\Query;
 use League\Uri\Modifier;
@@ -38,21 +39,52 @@ class ImageTransformer extends Component implements ImageTransformerInterface
             throw new NotSupportedException('SVG files shouldn’t be transformed.');
         }
 
-        $behavior = $imageTransform->getBehavior('cloud');
-
-        if (!$behavior instanceof ImageTransformBehavior) {
-            throw new \RuntimeException('Cloud image transform behavior is not attached.');
-        }
-
         $gravity = $this->applyAssetFocalPointGravity($asset, $imageTransform);
 
-        // @phpstan-ignore-next-line method.notFound
-        $query = Query::fromVariable($imageTransform->toOptions($gravity));
+        $query = Query::fromVariable($this->getTransformOptions($imageTransform, $gravity));
         $uri = Modifier::wrap($this->getAssetUri($asset))
             ->mergeQuery($query)
             ->unwrap();
 
         return Module::getInstance()->getUrlSigner()->sign((string) $uri);
+    }
+
+    public function getPdfTransformUrl(Asset $asset, mixed $transform): ?string
+    {
+        if ($asset->kind !== Asset::KIND_PDF) {
+            return null;
+        }
+
+        $assetFs = $this->getAssetCdnFs($asset);
+
+        if (!$assetFs) {
+            return null;
+        }
+
+        $imageTransform = $this->normalizeTransform($transform);
+
+        if (!$imageTransform) {
+            return null;
+        }
+
+        $options = $this->getTransformOptions($imageTransform);
+        $options['format'] ??= 'auto';
+
+        $query = Query::fromVariable($options);
+        $uri = Modifier::wrap($this->getAssetUri($asset, $assetFs))
+            ->mergeQuery($query)
+            ->unwrap();
+
+        return Module::getInstance()->getUrlSigner()->sign((string) $uri);
+    }
+
+    public function getPdfThumbUrl(Asset $asset, int $width, int $height): ?string
+    {
+        return $this->getPdfTransformUrl($asset, new ImageTransform([
+            'width' => $width,
+            'height' => $height,
+            'mode' => 'crop',
+        ]));
     }
 
     public function invalidateAssetTransforms(Asset $asset): void
@@ -69,9 +101,33 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         return $asset->getFocalPoint();
     }
 
-    private function getAssetUri(Asset $asset): Uri
+    private function getTransformOptions(ImageTransform $imageTransform, array|string|null $gravity = null): array
     {
-        $assetFs = $asset->getVolume()->getFs();
+        $behavior = $imageTransform->getBehavior('cloud');
+
+        if (!$behavior instanceof ImageTransformBehavior) {
+            throw new \RuntimeException('Cloud image transform behavior is not attached.');
+        }
+
+        return $behavior->toOptions($gravity);
+    }
+
+    private function normalizeTransform(mixed $transform): ?ImageTransform
+    {
+        if (is_array($transform)) {
+            foreach (['width', 'height'] as $attribute) {
+                if (isset($transform[$attribute])) {
+                    $transform[$attribute] = round((float)$transform[$attribute]);
+                }
+            }
+        }
+
+        return ImageTransformsHelper::normalizeTransform($transform);
+    }
+
+    private function getAssetUri(Asset $asset, ?AssetsFs $assetFs = null): Uri
+    {
+        $assetFs ??= $this->getAssetCdnFs($asset);
 
         if (version_compare(Craft::$app->version, '5.0', '>=')) {
             // @phpstan-ignore argument.type, arguments.count (Craft 5 compatibility)
@@ -85,7 +141,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
 
         $uri = Uri::new(Html::encodeSpaces($url));
 
-        if (!$assetFs instanceof AssetsFs || $assetFs->useLocalFs) {
+        if (!$assetFs) {
             return $uri;
         }
 
@@ -95,5 +151,16 @@ class ImageTransformer extends Component implements ImageTransformerInterface
             ->removeQueryParameters('v')
             ->removeEmptyQueryPairs()
             ->unwrap());
+    }
+
+    private function getAssetCdnFs(Asset $asset): ?AssetsFs
+    {
+        $assetFs = $asset->getVolume()->getFs();
+
+        if (!$assetFs instanceof AssetsFs || $assetFs->useLocalFs) {
+            return null;
+        }
+
+        return $assetFs;
     }
 }

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -107,7 +107,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
             // @phpstan-ignore argument.type, arguments.count (Craft 5 compatibility)
             $url = Assets::generateUrl($asset);
         } else {
-            $fs = $asset->getVolume()->getTransformFs();
+            $fs = $asset->getVolume()->getFs();
 
             // @phpstan-ignore argument.type, arguments.count (Craft 4 compatibility)
             $url = Assets::generateUrl($fs, $asset);

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -11,12 +11,10 @@ use craft\cloud\imagetransforms\ImageTransformer;
 use craft\cloud\Module as CloudModule;
 use craft\cloud\signing\UrlSigner;
 use craft\elements\Asset;
-use craft\events\GenerateTransformEvent;
 use craft\fs\Local;
 use craft\models\ImageTransform;
 use craft\models\Volume;
 use League\Uri\Components\Query;
-use ReflectionProperty;
 use yii\base\NotSupportedException;
 
 class ImageTransformTest extends Unit
@@ -239,42 +237,17 @@ class ImageTransformTest extends Unit
         $transformer->getTransformUrl($this->makePdfAssetStub(true, true), ['width' => 100], true);
     }
 
-    public function testEditImageActionUsesNativeTransforms(): void
+    public function testLocalCloudFsIsNotSignedByCloudTransformer(): void
     {
-        $module = new TestCloudModule('cloud-test');
-        $event = new GenerateTransformEvent([
-            'asset' => new TransformDecisionAsset(),
-            'transform' => new ImageTransform(['width' => 100]),
-        ]);
-        $request = Craft::$app->getRequest();
-        $isActionRequest = $request->getIsActionRequest();
-        $actionSegments = $request->getActionSegments();
+        $transformer = new ImageTransformer();
 
-        try {
-            $request->setIsActionRequest(true);
-            $this->setActionSegments(['assets', 'edit-image']);
-            $this->assertFalse($module->usesAssetCdnTransform($event));
+        $this->expectException(NotSupportedException::class);
 
-            $this->setActionSegments(['assets', 'generate-transform']);
-            $this->assertTrue($module->usesAssetCdnTransform($event));
-
-            $request->setIsActionRequest(false);
-            $this->setActionSegments(null);
-            $this->assertTrue($module->usesAssetCdnTransform($event));
-        } finally {
-            $request->setIsActionRequest($isActionRequest);
-            $this->setActionSegments($actionSegments);
-        }
-    }
-
-    public function testLocalCloudFsUsesNativeTransforms(): void
-    {
-        $event = new GenerateTransformEvent([
-            'asset' => new TransformDecisionAsset(true),
-            'transform' => new ImageTransform(['width' => 100]),
-        ]);
-
-        $this->assertFalse((new TestCloudModule('cloud-test'))->usesAssetCdnTransform($event));
+        $transformer->getTransformUrl(
+            $this->makeTransformUrlAsset('local.jpg', ['x' => 0.5, 'y' => 0.5], true),
+            new ImageTransform(['width' => 100]),
+            true,
+        );
     }
 
     public function testSupportedInputFormatsMatchCloudflareImages(): void
@@ -289,13 +262,6 @@ class ImageTransformTest extends Unit
             'avif',
             'heic',
         ], ImageTransformer::SUPPORTED_IMAGE_FORMATS);
-    }
-
-    private function setActionSegments(?array $actionSegments): void
-    {
-        $property = new ReflectionProperty(Craft::$app->getRequest(), '_actionSegments');
-        $property->setAccessible(true);
-        $property->setValue(Craft::$app->getRequest(), $actionSegments);
     }
 
     private function makeAssetStub(array $focalPoint): Asset
@@ -322,9 +288,9 @@ class ImageTransformTest extends Unit
         };
     }
 
-    private function makeTransformUrlAsset(string $filename, array $focalPoint): Asset
+    private function makeTransformUrlAsset(string $filename, array $focalPoint, bool $useLocalFs = false): Asset
     {
-        return new TransformUrlAsset($filename, $focalPoint);
+        return new TransformUrlAsset($filename, $focalPoint, $useLocalFs);
     }
 
     private function makePdfAssetStub(bool $useAssetCdn = true, bool $useLocalFs = false): Asset
@@ -427,6 +393,7 @@ class TransformUrlAsset extends Asset
     public function __construct(
         private string $filenameValue,
         private array $focalPointValue,
+        private bool $useLocalFs = false,
     ) {
         parent::__construct();
         $this->kind = self::KIND_IMAGE;
@@ -464,11 +431,16 @@ class TransformUrlAsset extends Asset
     public function getVolume(): Volume
     {
         return new Volume([
-            'fs' => new class() extends AssetsFs {
+            'fs' => new class($this->useLocalFs) extends AssetsFs {
+                public function __construct(private bool $assetUseLocalFs)
+                {
+                    parent::__construct();
+                }
+
                 public function init(): void
                 {
                     parent::init();
-                    $this->useLocalFs = false;
+                    $this->useLocalFs = $this->assetUseLocalFs;
                 }
 
                 public function getRootUrl(): ?string
@@ -477,47 +449,5 @@ class TransformUrlAsset extends Asset
                 }
             },
         ]);
-    }
-}
-
-class TestCloudModule extends CloudModule
-{
-    public function usesAssetCdnTransform(GenerateTransformEvent $event): bool
-    {
-        return $this->shouldUseAssetCdnTransform($event);
-    }
-}
-
-class TransformDecisionAsset extends Asset
-{
-    public function __construct(private bool $useLocalFs = false)
-    {
-        parent::__construct();
-    }
-
-    public function getVolume(): Volume
-    {
-        return new class($this->useLocalFs) extends Volume {
-            public function __construct(private bool $useLocalFs)
-            {
-                parent::__construct();
-            }
-
-            public function getFs(): AssetsFs
-            {
-                return new class($this->useLocalFs) extends AssetsFs {
-                    public function __construct(private bool $assetUseLocalFs)
-                    {
-                        parent::__construct();
-                    }
-
-                    public function init(): void
-                    {
-                        parent::init();
-                        $this->useLocalFs = $this->assetUseLocalFs;
-                    }
-                };
-            }
-        };
     }
 }

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -17,6 +17,7 @@ use craft\models\ImageTransform;
 use craft\models\Volume;
 use League\Uri\Components\Query;
 use ReflectionProperty;
+use yii\base\NotSupportedException;
 
 class ImageTransformTest extends Unit
 {
@@ -174,7 +175,15 @@ class ImageTransformTest extends Unit
     {
         $transformer = new ImageTransformer();
 
-        $signedUrl = $transformer->getPdfThumbUrl($this->makePdfAssetStub(), 320, 320);
+        $signedUrl = $transformer->getTransformUrl(
+            $this->makePdfAssetStub(),
+            new ImageTransform([
+                'width' => 320,
+                'height' => 320,
+                'mode' => 'crop',
+            ]),
+            true,
+        );
         $parameters = Query::fromUri($signedUrl)->parameters();
 
         $this->assertStringContainsString('/tests/document.pdf?', $signedUrl);
@@ -190,13 +199,17 @@ class ImageTransformTest extends Unit
     {
         $transformer = new ImageTransformer();
 
-        $signedUrl = $transformer->getPdfTransformUrl($this->makePdfAssetStub(), [
-            'width' => 640.4,
-            'height' => 480.4,
-            'format' => 'webp',
-            'mode' => 'fit',
-            'upscale' => false,
-        ]);
+        $signedUrl = $transformer->getTransformUrl(
+            $this->makePdfAssetStub(),
+            [
+                'width' => 640.4,
+                'height' => 480.4,
+                'format' => 'webp',
+                'mode' => 'fit',
+                'upscale' => false,
+            ],
+            true,
+        );
         $parameters = Query::fromUri($signedUrl)->parameters();
 
         $this->assertStringContainsString('/tests/document.pdf?', $signedUrl);
@@ -208,16 +221,13 @@ class ImageTransformTest extends Unit
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
     }
 
-    public function testPdfUrlsOnlyApplyToCloudPdfs(): void
+    public function testPdfTransformsRequireCloudAssets(): void
     {
         $transformer = new ImageTransformer();
-        $imageAsset = $this->makeTransformUrlAsset('test.jpg', ['x' => 0.5, 'y' => 0.5]);
-        $localPdfAsset = $this->makePdfAssetStub(false);
 
-        $this->assertNull($transformer->getPdfTransformUrl($imageAsset, ['width' => 100]));
-        $this->assertNull($transformer->getPdfThumbUrl($imageAsset, 100, 100));
-        $this->assertNull($transformer->getPdfTransformUrl($localPdfAsset, ['width' => 100]));
-        $this->assertNull($transformer->getPdfThumbUrl($localPdfAsset, 100, 100));
+        $this->expectException(NotSupportedException::class);
+
+        $transformer->getTransformUrl($this->makePdfAssetStub(false), ['width' => 100], true);
     }
 
     public function testEditImageActionUsesNativeTransforms(): void

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -4,6 +4,7 @@ namespace craft\cloud\tests\unit;
 
 use Codeception\Test\Unit;
 use Craft;
+use craft\base\FsInterface;
 use craft\cloud\fs\AssetsFs;
 use craft\cloud\imagetransforms\ImageTransformBehavior;
 use craft\cloud\imagetransforms\ImageTransformer;
@@ -11,6 +12,7 @@ use craft\cloud\Module as CloudModule;
 use craft\cloud\signing\UrlSigner;
 use craft\elements\Asset;
 use craft\events\GenerateTransformEvent;
+use craft\fs\Local;
 use craft\models\ImageTransform;
 use craft\models\Volume;
 use League\Uri\Components\Query;
@@ -168,6 +170,56 @@ class ImageTransformTest extends Unit
         }
     }
 
+    public function testPdfThumbUrlUsesSignedRasterTransform(): void
+    {
+        $transformer = new ImageTransformer();
+
+        $signedUrl = $transformer->getPdfThumbUrl($this->makePdfAssetStub(), 320, 320);
+        $parameters = Query::fromUri($signedUrl)->parameters();
+
+        $this->assertStringContainsString('/tests/document.pdf?', $signedUrl);
+        $this->assertSame('auto', $parameters['format']);
+        $this->assertSame('320', $parameters['width']);
+        $this->assertSame('320', $parameters['height']);
+        $this->assertArrayNotHasKey('page', $parameters);
+        $this->assertSame('cover', $parameters['fit']);
+        $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
+    }
+
+    public function testPdfTransformUrlUsesSignedRasterTransform(): void
+    {
+        $transformer = new ImageTransformer();
+
+        $signedUrl = $transformer->getPdfTransformUrl($this->makePdfAssetStub(), [
+            'width' => 640.4,
+            'height' => 480.4,
+            'format' => 'webp',
+            'mode' => 'fit',
+            'upscale' => false,
+        ]);
+        $parameters = Query::fromUri($signedUrl)->parameters();
+
+        $this->assertStringContainsString('/tests/document.pdf?', $signedUrl);
+        $this->assertSame('webp', $parameters['format']);
+        $this->assertSame('640', $parameters['width']);
+        $this->assertSame('480', $parameters['height']);
+        $this->assertSame('scale-down', $parameters['fit']);
+        $this->assertArrayNotHasKey('page', $parameters);
+        $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
+    }
+
+    public function testPdfUrlsOnlyApplyToCloudPdfs(): void
+    {
+        $transformer = new ImageTransformer();
+        $imageAsset = $this->makeTransformUrlAsset('test.jpg', ['x' => 0.5, 'y' => 0.5]);
+        $localPdfAsset = $this->makePdfAssetStub(false);
+
+        $this->assertNull($transformer->getPdfTransformUrl($imageAsset, ['width' => 100]));
+        $this->assertNull($transformer->getPdfThumbUrl($imageAsset, 100, 100));
+        $this->assertNull($transformer->getPdfTransformUrl($localPdfAsset, ['width' => 100]));
+        $this->assertNull($transformer->getPdfThumbUrl($localPdfAsset, 100, 100));
+    }
+
     public function testEditImageActionUsesNativeTransforms(): void
     {
         $module = new TestCloudModule('cloud-test');
@@ -244,6 +296,61 @@ class ImageTransformTest extends Unit
     private function makeTransformUrlAsset(string $filename, array $focalPoint): Asset
     {
         return new TransformUrlAsset($filename, $focalPoint);
+    }
+
+    private function makePdfAssetStub(bool $useAssetCdn = true): Asset
+    {
+        return new class($useAssetCdn) extends Asset {
+            public function __construct(private bool $useAssetCdn)
+            {
+                parent::__construct();
+                $this->kind = self::KIND_PDF;
+                $this->folderPath = 'tests/';
+            }
+
+            public function getFilename(bool $withExtension = true): string
+            {
+                return 'document.pdf';
+            }
+
+            public function getPath(?string $filename = null): string
+            {
+                return 'tests/' . ($filename ?? 'document.pdf');
+            }
+
+            public function getVolume(): Volume
+            {
+                return new class($this->useAssetCdn) extends Volume {
+                    public function __construct(private bool $useAssetCdn)
+                    {
+                        parent::__construct();
+                    }
+
+                    public function getFs(): FsInterface
+                    {
+                        return $this->useAssetCdn
+                            ? new class() extends AssetsFs {
+                                public function init(): void
+                                {
+                                    parent::init();
+                                    $this->useLocalFs = false;
+                                }
+                            }
+                        : new Local(['path' => Craft::getAlias('@runtime')]);
+                    }
+
+                    public function getTransformFs(): FsInterface
+                    {
+                        return $this->getFs();
+                    }
+
+                    public function getRootUrl(): ?string
+                    {
+                        return 'https://cdn.craft.cloud/test-environment/assets/';
+                    }
+                };
+            }
+        };
     }
 
     private function behavior(ImageTransform $transform): ImageTransformBehavior

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -198,18 +198,16 @@ class ImageTransformTest extends Unit
     public function testPdfTransformUrlUsesSignedRasterTransform(): void
     {
         $transformer = new ImageTransformer();
-        $imageTransform = $transformer->normalizeTransform([
-            'width' => 640.4,
-            'height' => 480.4,
-            'format' => 'webp',
-            'mode' => 'fit',
-            'upscale' => false,
-        ]);
 
-        $this->assertInstanceOf(ImageTransform::class, $imageTransform);
         $signedUrl = $transformer->getTransformUrl(
             $this->makePdfAssetStub(),
-            $imageTransform,
+            [
+                'width' => 640.4,
+                'height' => 480.4,
+                'format' => 'webp',
+                'mode' => 'fit',
+                'upscale' => false,
+            ],
             true,
         );
         $parameters = Query::fromUri($signedUrl)->parameters();
@@ -226,12 +224,19 @@ class ImageTransformTest extends Unit
     public function testPdfTransformsRequireCloudAssets(): void
     {
         $transformer = new ImageTransformer();
-        $imageTransform = $transformer->normalizeTransform(['width' => 100]);
 
-        $this->assertInstanceOf(ImageTransform::class, $imageTransform);
         $this->expectException(NotSupportedException::class);
 
-        $transformer->getTransformUrl($this->makePdfAssetStub(false), $imageTransform, true);
+        $transformer->getTransformUrl($this->makePdfAssetStub(false), ['width' => 100], true);
+    }
+
+    public function testPdfTransformsRequireRemoteCloudAssets(): void
+    {
+        $transformer = new ImageTransformer();
+
+        $this->expectException(NotSupportedException::class);
+
+        $transformer->getTransformUrl($this->makePdfAssetStub(true, true), ['width' => 100], true);
     }
 
     public function testEditImageActionUsesNativeTransforms(): void
@@ -256,6 +261,9 @@ class ImageTransformTest extends Unit
             $request->setIsActionRequest(false);
             $this->setActionSegments(null);
             $this->assertTrue($module->usesAssetCdnTransform($event));
+
+            $event->asset = new TransformDecisionAsset(true);
+            $this->assertFalse($module->usesAssetCdnTransform($event));
         } finally {
             $request->setIsActionRequest($isActionRequest);
             $this->setActionSegments($actionSegments);
@@ -312,11 +320,13 @@ class ImageTransformTest extends Unit
         return new TransformUrlAsset($filename, $focalPoint);
     }
 
-    private function makePdfAssetStub(bool $useAssetCdn = true): Asset
+    private function makePdfAssetStub(bool $useAssetCdn = true, bool $useLocalFs = false): Asset
     {
-        return new class($useAssetCdn) extends Asset {
-            public function __construct(private bool $useAssetCdn)
-            {
+        return new class($useAssetCdn, $useLocalFs) extends Asset {
+            public function __construct(
+                private bool $useAssetCdn,
+                private bool $useLocalFs,
+            ) {
                 parent::__construct();
                 $this->kind = self::KIND_PDF;
                 $this->folderPath = 'tests/';
@@ -334,20 +344,27 @@ class ImageTransformTest extends Unit
 
             public function getVolume(): Volume
             {
-                return new class($this->useAssetCdn) extends Volume {
-                    public function __construct(private bool $useAssetCdn)
-                    {
+                return new class($this->useAssetCdn, $this->useLocalFs) extends Volume {
+                    public function __construct(
+                        private bool $useAssetCdn,
+                        private bool $useLocalFs,
+                    ) {
                         parent::__construct();
                     }
 
                     public function getFs(): FsInterface
                     {
                         return $this->useAssetCdn
-                            ? new class() extends AssetsFs {
+                            ? new class($this->useLocalFs) extends AssetsFs {
+                                public function __construct(private bool $assetUseLocalFs)
+                                {
+                                    parent::__construct();
+                                }
+
                                 public function init(): void
                                 {
                                     parent::init();
-                                    $this->useLocalFs = false;
+                                    $this->useLocalFs = $this->assetUseLocalFs;
                                 }
                             }
                         : new Local(['path' => Craft::getAlias('@runtime')]);
@@ -466,12 +483,33 @@ class TestCloudModule extends CloudModule
 
 class TransformDecisionAsset extends Asset
 {
+    public function __construct(private bool $useLocalFs = false)
+    {
+        parent::__construct();
+    }
+
     public function getVolume(): Volume
     {
-        return new class() extends Volume {
+        return new class($this->useLocalFs) extends Volume {
+            public function __construct(private bool $useLocalFs)
+            {
+                parent::__construct();
+            }
+
             public function getFs(): AssetsFs
             {
-                return new AssetsFs();
+                return new class($this->useLocalFs) extends AssetsFs {
+                    public function __construct(private bool $assetUseLocalFs)
+                    {
+                        parent::__construct();
+                    }
+
+                    public function init(): void
+                    {
+                        parent::init();
+                        $this->useLocalFs = $this->assetUseLocalFs;
+                    }
+                };
             }
         };
     }

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -11,10 +11,12 @@ use craft\cloud\imagetransforms\ImageTransformer;
 use craft\cloud\Module as CloudModule;
 use craft\cloud\signing\UrlSigner;
 use craft\elements\Asset;
+use craft\events\GenerateTransformEvent;
 use craft\fs\Local;
 use craft\models\ImageTransform;
 use craft\models\Volume;
 use League\Uri\Components\Query;
+use ReflectionProperty;
 use yii\base\NotSupportedException;
 
 class ImageTransformTest extends Unit
@@ -169,6 +171,40 @@ class ImageTransformTest extends Unit
         }
     }
 
+    public function testEditImageActionUsesNativeTransforms(): void
+    {
+        $module = new TestCloudModule('cloud-test');
+        $event = new GenerateTransformEvent([
+            'asset' => new TransformDecisionAsset(),
+            'transform' => new ImageTransform(['width' => 100]),
+        ]);
+        $localEvent = new GenerateTransformEvent([
+            'asset' => $this->makeTransformUrlAsset('local.jpg', ['x' => 0.5, 'y' => 0.5], true),
+            'transform' => new ImageTransform(['width' => 100]),
+        ]);
+        $request = Craft::$app->getRequest();
+        $isActionRequest = $request->getIsActionRequest();
+        $actionSegments = $request->getActionSegments();
+
+        try {
+            $this->assertFalse($module->usesAssetCdnTransform($localEvent));
+
+            $request->setIsActionRequest(true);
+            $this->setActionSegments(['assets', 'edit-image']);
+            $this->assertFalse($module->usesAssetCdnTransform($event));
+
+            $this->setActionSegments(['assets', 'generate-transform']);
+            $this->assertTrue($module->usesAssetCdnTransform($event));
+
+            $request->setIsActionRequest(false);
+            $this->setActionSegments(null);
+            $this->assertTrue($module->usesAssetCdnTransform($event));
+        } finally {
+            $request->setIsActionRequest($isActionRequest);
+            $this->setActionSegments($actionSegments);
+        }
+    }
+
     public function testPdfThumbUrlUsesSignedRasterTransform(): void
     {
         $transformer = new ImageTransformer();
@@ -262,6 +298,13 @@ class ImageTransformTest extends Unit
             'avif',
             'heic',
         ], ImageTransformer::SUPPORTED_IMAGE_FORMATS);
+    }
+
+    private function setActionSegments(?array $actionSegments): void
+    {
+        $property = new ReflectionProperty(Craft::$app->getRequest(), '_actionSegments');
+        $property->setAccessible(true);
+        $property->setValue(Craft::$app->getRequest(), $actionSegments);
     }
 
     private function makeAssetStub(array $focalPoint): Asset
@@ -385,6 +428,33 @@ class UrlTestImageTransformer extends ImageTransformer
         $behavior = $imageTransform->getBehavior('cloud');
 
         return (string) \League\Uri\Components\Query::fromVariable($behavior->toOptions($gravity));
+    }
+}
+
+class TestCloudModule extends CloudModule
+{
+    public function usesAssetCdnTransform(GenerateTransformEvent $event): bool
+    {
+        return $this->shouldUseAssetCdnTransform($event);
+    }
+}
+
+class TransformDecisionAsset extends Asset
+{
+    public function getVolume(): Volume
+    {
+        return new class() extends Volume {
+            public function getFs(): AssetsFs
+            {
+                return new class() extends AssetsFs {
+                    public function init(): void
+                    {
+                        parent::init();
+                        $this->useLocalFs = false;
+                    }
+                };
+            }
+        };
     }
 }
 

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -261,13 +261,20 @@ class ImageTransformTest extends Unit
             $request->setIsActionRequest(false);
             $this->setActionSegments(null);
             $this->assertTrue($module->usesAssetCdnTransform($event));
-
-            $event->asset = new TransformDecisionAsset(true);
-            $this->assertFalse($module->usesAssetCdnTransform($event));
         } finally {
             $request->setIsActionRequest($isActionRequest);
             $this->setActionSegments($actionSegments);
         }
+    }
+
+    public function testLocalCloudFsUsesNativeTransforms(): void
+    {
+        $event = new GenerateTransformEvent([
+            'asset' => new TransformDecisionAsset(true),
+            'transform' => new ImageTransform(['width' => 100]),
+        ]);
+
+        $this->assertFalse((new TestCloudModule('cloud-test'))->usesAssetCdnTransform($event));
     }
 
     public function testSupportedInputFormatsMatchCloudflareImages(): void

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -198,16 +198,18 @@ class ImageTransformTest extends Unit
     public function testPdfTransformUrlUsesSignedRasterTransform(): void
     {
         $transformer = new ImageTransformer();
+        $imageTransform = $transformer->normalizeTransform([
+            'width' => 640.4,
+            'height' => 480.4,
+            'format' => 'webp',
+            'mode' => 'fit',
+            'upscale' => false,
+        ]);
 
+        $this->assertInstanceOf(ImageTransform::class, $imageTransform);
         $signedUrl = $transformer->getTransformUrl(
             $this->makePdfAssetStub(),
-            [
-                'width' => 640.4,
-                'height' => 480.4,
-                'format' => 'webp',
-                'mode' => 'fit',
-                'upscale' => false,
-            ],
+            $imageTransform,
             true,
         );
         $parameters = Query::fromUri($signedUrl)->parameters();
@@ -224,10 +226,12 @@ class ImageTransformTest extends Unit
     public function testPdfTransformsRequireCloudAssets(): void
     {
         $transformer = new ImageTransformer();
+        $imageTransform = $transformer->normalizeTransform(['width' => 100]);
 
+        $this->assertInstanceOf(ImageTransform::class, $imageTransform);
         $this->expectException(NotSupportedException::class);
 
-        $transformer->getTransformUrl($this->makePdfAssetStub(false), ['width' => 100], true);
+        $transformer->getTransformUrl($this->makePdfAssetStub(false), $imageTransform, true);
     }
 
     public function testEditImageActionUsesNativeTransforms(): void


### PR DESCRIPTION
Adds Craft-side PDF transform URL support without adding PDF to Craft’s global image format gate.

PDF transform and thumbnail URLs now use the signed CDN transform path with `format=auto`, while ordinary PDF delivery stays unchanged. This pairs with the cloud-gateway-worker PDF raster transform support.