### PR TITLE
Render Cloud PDF transforms as images

### DIFF
--- a/src/imagetransforms/ImageTransformBehavior.php
+++ b/src/imagetransforms/ImageTransformBehavior.php
@@ -79,6 +79,11 @@ class ImageTransformBehavior extends Behavior
     public ?string $metadata = null;
 
     /**
+     * @var int|null PDF page number.
+     */
+    public ?int $page = null;
+
+    /**
      * @var int|null
      */
     public ?int $rotate = null;

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -99,6 +99,10 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 }
             }
 
+            if (isset($transform['page']) && is_numeric($transform['page'])) {
+                $transform['page'] = (int)$transform['page'];
+            }
+
             if (array_key_exists('transform', $transform) && array_key_exists('page', $transform)) {
                 $page = $transform['page'];
             }

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -90,7 +90,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
 
     private function normalizeTransform(mixed $transform): ?ImageTransform
     {
-        $page = null;
+        $cloudOptions = [];
 
         if (is_array($transform)) {
             foreach (['width', 'height'] as $attribute) {
@@ -99,27 +99,43 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 }
             }
 
-            if (array_key_exists('page', $transform)) {
-                $normalizedPage = is_int($transform['page']) || is_string($transform['page'])
-                    ? filter_var($transform['page'], FILTER_VALIDATE_INT)
+            foreach ((new \ReflectionClass(ImageTransformBehavior::class))->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+                if ($property->getDeclaringClass()->getName() !== ImageTransformBehavior::class) {
+                    continue;
+                }
+
+                $name = $property->getName();
+
+                if (!array_key_exists($name, $transform)) {
+                    continue;
+                }
+
+                $cloudOptions[$name] = $transform[$name];
+                unset($transform[$name]);
+            }
+
+            if (array_key_exists('page', $cloudOptions)) {
+                $normalizedPage = is_int($cloudOptions['page']) || is_string($cloudOptions['page'])
+                    ? filter_var($cloudOptions['page'], FILTER_VALIDATE_INT)
                     : false;
 
                 if ($normalizedPage !== false && $normalizedPage >= 1) {
-                    $page = $normalizedPage;
+                    $cloudOptions['page'] = $normalizedPage;
+                } else {
+                    unset($cloudOptions['page']);
                 }
-
-                unset($transform['page']);
             }
         }
 
-        $imageTransform = ImageTransformsHelper::normalizeTransform($transform);
+        $imageTransform = ImageTransformsHelper::normalizeTransform($transform)
+            ?? ($cloudOptions ? Craft::createObject(ImageTransform::class) : null);
 
-        if ($imageTransform && $page !== null) {
+        if ($imageTransform && $cloudOptions) {
             $imageTransform = clone $imageTransform;
             $behavior = $imageTransform->getBehavior('cloud');
 
             if ($behavior instanceof ImageTransformBehavior) {
-                $behavior->page = $page;
+                Craft::configure($behavior, $cloudOptions);
             }
         }
 

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -104,21 +104,18 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                     ? filter_var($transform['page'], FILTER_VALIDATE_INT)
                     : false;
 
-                if ($normalizedPage !== false) {
-                    $transform['page'] = $normalizedPage;
-                } else {
-                    unset($transform['page']);
+                if ($normalizedPage !== false && $normalizedPage >= 1) {
+                    $page = $normalizedPage;
                 }
-            }
 
-            if (array_key_exists('transform', $transform) && array_key_exists('page', $transform)) {
-                $page = $transform['page'];
+                unset($transform['page']);
             }
         }
 
         $imageTransform = ImageTransformsHelper::normalizeTransform($transform);
 
         if ($imageTransform && $page !== null) {
+            $imageTransform = clone $imageTransform;
             $behavior = $imageTransform->getBehavior('cloud');
 
             if ($behavior instanceof ImageTransformBehavior) {

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -90,7 +90,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
 
     private function normalizeTransform(mixed $transform): ?ImageTransform
     {
-        $cloudTransformOptions = [];
+        $cloudOptions = [];
 
         if (is_array($transform)) {
             foreach (['width', 'height'] as $attribute) {
@@ -109,7 +109,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 [$valid, $value] = $this->normalizeCloudOption($property, $transform[$name]);
 
                 if ($valid) {
-                    $cloudTransformOptions[$name] = $value;
+                    $cloudOptions[$name] = $value;
                 }
 
                 unset($transform[$name]);
@@ -117,14 +117,14 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         }
 
         $imageTransform = ImageTransformsHelper::normalizeTransform($transform)
-            ?? ($cloudTransformOptions ? Craft::createObject(ImageTransform::class) : null);
+            ?? ($cloudOptions ? Craft::createObject(ImageTransform::class) : null);
 
-        if ($imageTransform && $cloudTransformOptions) {
+        if ($imageTransform && $cloudOptions) {
             $imageTransform = clone $imageTransform;
             $behavior = $imageTransform->getBehavior('cloud');
 
             if ($behavior instanceof ImageTransformBehavior) {
-                Craft::configure($behavior, $cloudTransformOptions);
+                Craft::configure($behavior, $cloudOptions);
             }
         }
 

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -91,6 +91,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
     private function normalizeTransform(mixed $transform): ?ImageTransform
     {
         $cloudOptions = [];
+        static $cloudOptionProperties = null;
 
         if (is_array($transform)) {
             foreach (['width', 'height'] as $attribute) {
@@ -99,11 +100,12 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 }
             }
 
-            foreach ((new \ReflectionClass(ImageTransformBehavior::class))->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
-                if ($property->getDeclaringClass()->getName() !== ImageTransformBehavior::class) {
-                    continue;
-                }
+            $cloudOptionProperties ??= array_filter(
+                (new \ReflectionClass(ImageTransformBehavior::class))->getProperties(\ReflectionProperty::IS_PUBLIC),
+                fn(\ReflectionProperty $property) => $property->getDeclaringClass()->getName() === ImageTransformBehavior::class,
+            );
 
+            foreach ($cloudOptionProperties as $property) {
                 $name = $property->getName();
 
                 if (!array_key_exists($name, $transform)) {

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -90,15 +90,31 @@ class ImageTransformer extends Component implements ImageTransformerInterface
 
     private function normalizeTransform(mixed $transform): ?ImageTransform
     {
+        $page = null;
+
         if (is_array($transform)) {
             foreach (['width', 'height'] as $attribute) {
                 if (isset($transform[$attribute])) {
                     $transform[$attribute] = round((float)$transform[$attribute]);
                 }
             }
+
+            if (array_key_exists('transform', $transform) && array_key_exists('page', $transform)) {
+                $page = $transform['page'];
+            }
         }
 
-        return ImageTransformsHelper::normalizeTransform($transform);
+        $imageTransform = ImageTransformsHelper::normalizeTransform($transform);
+
+        if ($imageTransform && $page !== null) {
+            $behavior = $imageTransform->getBehavior('cloud');
+
+            if ($behavior instanceof ImageTransformBehavior) {
+                $behavior->page = $page;
+            }
+        }
+
+        return $imageTransform;
     }
 
     private function createBaseUri(Asset $asset): Uri

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -99,7 +99,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 }
             }
 
-            foreach ($this->cloudOptionProperties() as $property) {
+            foreach ($this->cloudProperties() as $property) {
                 $name = $property->getName();
 
                 if (!array_key_exists($name, $transform)) {
@@ -131,7 +131,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         return $imageTransform;
     }
 
-    private function cloudOptionProperties(): array
+    private function cloudProperties(): array
     {
         static $properties = null;
 

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -90,8 +90,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
 
     private function normalizeTransform(mixed $transform): ?ImageTransform
     {
-        $cloudOptions = [];
-        static $cloudOptionProperties = null;
+        $cloudTransformOptions = [];
 
         if (is_array($transform)) {
             foreach (['width', 'height'] as $attribute) {
@@ -100,12 +99,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 }
             }
 
-            $cloudOptionProperties ??= array_filter(
-                (new \ReflectionClass(ImageTransformBehavior::class))->getProperties(\ReflectionProperty::IS_PUBLIC),
-                fn(\ReflectionProperty $property) => $property->getDeclaringClass()->getName() === ImageTransformBehavior::class,
-            );
-
-            foreach ($cloudOptionProperties as $property) {
+            foreach ($this->cloudOptionProperties() as $property) {
                 $name = $property->getName();
 
                 if (!array_key_exists($name, $transform)) {
@@ -115,7 +109,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 [$valid, $value] = $this->normalizeCloudOption($property, $transform[$name]);
 
                 if ($valid) {
-                    $cloudOptions[$name] = $value;
+                    $cloudTransformOptions[$name] = $value;
                 }
 
                 unset($transform[$name]);
@@ -123,18 +117,28 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         }
 
         $imageTransform = ImageTransformsHelper::normalizeTransform($transform)
-            ?? ($cloudOptions ? Craft::createObject(ImageTransform::class) : null);
+            ?? ($cloudTransformOptions ? Craft::createObject(ImageTransform::class) : null);
 
-        if ($imageTransform && $cloudOptions) {
+        if ($imageTransform && $cloudTransformOptions) {
             $imageTransform = clone $imageTransform;
             $behavior = $imageTransform->getBehavior('cloud');
 
             if ($behavior instanceof ImageTransformBehavior) {
-                Craft::configure($behavior, $cloudOptions);
+                Craft::configure($behavior, $cloudTransformOptions);
             }
         }
 
         return $imageTransform;
+    }
+
+    private function cloudOptionProperties(): array
+    {
+        static $properties = null;
+
+        return $properties ??= array_filter(
+            (new \ReflectionClass(ImageTransformBehavior::class))->getProperties(\ReflectionProperty::IS_PUBLIC),
+            fn(\ReflectionProperty $property) => $property->getDeclaringClass()->getName() === ImageTransformBehavior::class,
+        );
     }
 
     private function normalizeCloudOption(\ReflectionProperty $property, mixed $value): array

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -100,8 +100,12 @@ class ImageTransformer extends Component implements ImageTransformerInterface
             }
 
             if (array_key_exists('page', $transform)) {
-                if (is_numeric($transform['page'])) {
-                    $transform['page'] = (int)$transform['page'];
+                $normalizedPage = is_int($transform['page']) || is_string($transform['page'])
+                    ? filter_var($transform['page'], FILTER_VALIDATE_INT)
+                    : false;
+
+                if ($normalizedPage !== false) {
+                    $transform['page'] = $normalizedPage;
                 } else {
                     unset($transform['page']);
                 }

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -99,8 +99,12 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                 }
             }
 
-            if (isset($transform['page']) && is_numeric($transform['page'])) {
-                $transform['page'] = (int)$transform['page'];
+            if (array_key_exists('page', $transform)) {
+                if (is_numeric($transform['page'])) {
+                    $transform['page'] = (int)$transform['page'];
+                } else {
+                    unset($transform['page']);
+                }
             }
 
             if (array_key_exists('transform', $transform) && array_key_exists('page', $transform)) {

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -174,6 +174,14 @@ class ImageTransformer extends Component implements ImageTransformerInterface
             return [$value !== null, $value];
         }
 
+        if (in_array('string', $types, true) || in_array('array', $types, true)) {
+            return [
+                (in_array('string', $types, true) && is_string($value)) ||
+                (in_array('array', $types, true) && is_array($value)),
+                $value,
+            ];
+        }
+
         return [true, $value];
     }
 

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -110,20 +110,13 @@ class ImageTransformer extends Component implements ImageTransformerInterface
                     continue;
                 }
 
-                $cloudOptions[$name] = $transform[$name];
-                unset($transform[$name]);
-            }
+                [$valid, $value] = $this->normalizeCloudOption($property, $transform[$name]);
 
-            if (array_key_exists('page', $cloudOptions)) {
-                $normalizedPage = is_int($cloudOptions['page']) || is_string($cloudOptions['page'])
-                    ? filter_var($cloudOptions['page'], FILTER_VALIDATE_INT)
-                    : false;
-
-                if ($normalizedPage !== false && $normalizedPage >= 1) {
-                    $cloudOptions['page'] = $normalizedPage;
-                } else {
-                    unset($cloudOptions['page']);
+                if ($valid) {
+                    $cloudOptions[$name] = $value;
                 }
+
+                unset($transform[$name]);
             }
         }
 
@@ -140,6 +133,42 @@ class ImageTransformer extends Component implements ImageTransformerInterface
         }
 
         return $imageTransform;
+    }
+
+    private function normalizeCloudOption(\ReflectionProperty $property, mixed $value): array
+    {
+        if ($value === null) {
+            return [true, null];
+        }
+
+        $type = $property->getType();
+        $types = $type instanceof \ReflectionUnionType
+            ? array_map(fn(\ReflectionNamedType $type) => $type->getName(), $type->getTypes())
+            : ($type instanceof \ReflectionNamedType ? [$type->getName()] : []);
+
+        if (in_array('int', $types, true)) {
+            $value = is_int($value) || is_string($value)
+                ? filter_var($value, FILTER_VALIDATE_INT)
+                : false;
+
+            return [$value !== false && ($property->getName() !== 'page' || $value >= 1), $value];
+        }
+
+        if (in_array('float', $types, true)) {
+            $value = is_int($value) || is_float($value) || is_string($value)
+                ? filter_var($value, FILTER_VALIDATE_FLOAT)
+                : false;
+
+            return [$value !== false, $value];
+        }
+
+        if (in_array('bool', $types, true)) {
+            $value = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+
+            return [$value !== null, $value];
+        }
+
+        return [true, $value];
     }
 
     private function createBaseUri(Asset $asset): Uri

--- a/src/twig/CloudVariable.php
+++ b/src/twig/CloudVariable.php
@@ -47,7 +47,11 @@ class CloudVariable extends ServiceLocator
         $transformForAttributes = $transform;
 
         if (is_array($transformForAttributes)) {
-            unset($transformForAttributes['page']);
+            $transformForAttributes = array_intersect_key($transformForAttributes, array_flip([
+                'height',
+                'transform',
+                'width',
+            ]));
         }
 
         $imageTransform = ImageTransforms::normalizeTransform($transformForAttributes);

--- a/src/twig/CloudVariable.php
+++ b/src/twig/CloudVariable.php
@@ -9,6 +9,9 @@ namespace craft\cloud\twig;
 
 use craft\cloud\Helper;
 use craft\cloud\Module;
+use craft\elements\Asset;
+use craft\helpers\Html;
+use craft\helpers\ImageTransforms;
 use craft\helpers\Template;
 use Twig\Markup;
 use yii\di\ServiceLocator;
@@ -23,6 +26,39 @@ class CloudVariable extends ServiceLocator
     public function isCraftCloud(): bool
     {
         return Helper::isCraftCloud();
+    }
+
+    public function getImg(Asset $asset, mixed $transform = null, ?array $sizes = null): ?Markup
+    {
+        if ($asset->kind !== Asset::KIND_PDF) {
+            return $asset->getImg($transform, $sizes);
+        }
+
+        if (!$transform) {
+            return null;
+        }
+
+        $url = $asset->getUrl($transform);
+
+        if (!$url || !Module::getInstance()->getUrlSigner()->verify($url)) {
+            return null;
+        }
+
+        $imageTransform = ImageTransforms::normalizeTransform($transform);
+        $attributes = [
+            'src' => $url,
+            'alt' => $asset->alt ?? $asset->getFilename(),
+        ];
+
+        if ($imageTransform?->width !== null) {
+            $attributes['width'] = $imageTransform->width;
+        }
+
+        if ($imageTransform?->height !== null) {
+            $attributes['height'] = $imageTransform->height;
+        }
+
+        return Template::raw(Html::tag('img', '', $attributes));
     }
 
     public function enableEsi(): void

--- a/src/twig/CloudVariable.php
+++ b/src/twig/CloudVariable.php
@@ -44,7 +44,13 @@ class CloudVariable extends ServiceLocator
             return null;
         }
 
-        $imageTransform = ImageTransforms::normalizeTransform($transform);
+        $transformForAttributes = $transform;
+
+        if (is_array($transformForAttributes)) {
+            unset($transformForAttributes['page']);
+        }
+
+        $imageTransform = ImageTransforms::normalizeTransform($transformForAttributes);
         $attributes = [
             'src' => $url,
             'alt' => $asset->alt ?? $asset->getFilename(),

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -10,13 +10,16 @@ use craft\cloud\imagetransforms\ImageTransformBehavior;
 use craft\cloud\imagetransforms\ImageTransformer;
 use craft\cloud\Module as CloudModule;
 use craft\cloud\signing\UrlSigner;
+use craft\cloud\twig\CloudVariable;
 use craft\elements\Asset;
 use craft\events\GenerateTransformEvent;
 use craft\fs\Local;
+use craft\helpers\Template;
 use craft\models\ImageTransform;
 use craft\models\Volume;
 use League\Uri\Components\Query;
 use ReflectionProperty;
+use Twig\Markup;
 use yii\base\NotSupportedException;
 
 class ImageTransformTest extends Unit
@@ -240,6 +243,7 @@ class ImageTransformTest extends Unit
                 'height' => 480.4,
                 'format' => 'webp',
                 'mode' => 'fit',
+                'page' => 2,
                 'upscale' => false,
             ],
             true,
@@ -251,8 +255,53 @@ class ImageTransformTest extends Unit
         $this->assertSame('640', $parameters['width']);
         $this->assertSame('480', $parameters['height']);
         $this->assertSame('scale-down', $parameters['fit']);
-        $this->assertArrayNotHasKey('page', $parameters);
+        $this->assertSame('2', $parameters['page']);
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
+    }
+
+    public function testCloudGetImgDelegatesToNativeImageRendering(): void
+    {
+        $asset = new DelegatingImageAsset();
+        $transform = ['width' => 100];
+        $sizes = ['1x', '2x'];
+
+        $img = (new CloudVariable())->getImg($asset, $transform, $sizes);
+
+        $this->assertSame('<img src="delegated">', (string) $img);
+        $this->assertSame($transform, $asset->receivedTransform);
+        $this->assertSame($sizes, $asset->receivedSizes);
+    }
+
+    public function testCloudGetImgRendersSignedPdfTransform(): void
+    {
+        $transform = [
+            'page' => 1,
+            'width' => 320,
+            'height' => 240,
+        ];
+
+        $img = (new CloudVariable())->getImg(new SignedPdfImageAsset(), $transform);
+        $src = $this->imgSrc($img);
+        $parameters = Query::fromUri($src)->parameters();
+
+        $this->assertStringStartsWith('<img ', (string) $img);
+        $this->assertStringContainsString('width="320"', (string) $img);
+        $this->assertStringContainsString('height="240"', (string) $img);
+        $this->assertStringContainsString('alt="document.pdf"', (string) $img);
+        $this->assertStringContainsString('/tests/document.pdf?', $src);
+        $this->assertSame('auto', $parameters['format']);
+        $this->assertSame('1', $parameters['page']);
+        $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($src));
+    }
+
+    public function testCloudGetImgRequiresPdfTransform(): void
+    {
+        $this->assertNull((new CloudVariable())->getImg(new UnsignedPdfImageAsset()));
+    }
+
+    public function testCloudGetImgDoesNotRenderUnsignedPdfUrl(): void
+    {
+        $this->assertNull((new CloudVariable())->getImg(new UnsignedPdfImageAsset(), ['page' => 1]));
     }
 
     public function testPdfTransformsRequireCloudAssets(): void
@@ -408,6 +457,14 @@ class ImageTransformTest extends Unit
 
         return $behavior;
     }
+
+    private function imgSrc(?Markup $img): string
+    {
+        $this->assertNotNull($img);
+        $this->assertSame(1, preg_match('/\bsrc="([^"]+)"/', (string) $img, $matches));
+
+        return html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5);
+    }
 }
 
 class TestImageTransformer extends ImageTransformer
@@ -455,6 +512,83 @@ class TransformDecisionAsset extends Asset
                 };
             }
         };
+    }
+}
+
+class DelegatingImageAsset extends Asset
+{
+    public mixed $receivedTransform = null;
+    public ?array $receivedSizes = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->kind = self::KIND_IMAGE;
+    }
+
+    public function getImg(mixed $transform = null, ?array $sizes = null): ?Markup
+    {
+        $this->receivedTransform = $transform;
+        $this->receivedSizes = $sizes;
+
+        return Template::raw('<img src="delegated">');
+    }
+}
+
+class SignedPdfImageAsset extends Asset
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->kind = self::KIND_PDF;
+        $this->folderPath = 'tests/';
+    }
+
+    public function getFilename(bool $withExtension = true): string
+    {
+        return 'document.pdf';
+    }
+
+    public function getPath(?string $filename = null): string
+    {
+        return 'tests/' . ($filename ?? 'document.pdf');
+    }
+
+    public function getUrl(mixed $transform = null, ?bool $immediately = null): ?string
+    {
+        return (new ImageTransformer())->getTransformUrl($this, $transform, true);
+    }
+
+    public function getVolume(): Volume
+    {
+        return new Volume([
+            'fs' => new class() extends AssetsFs {
+                public function init(): void
+                {
+                    parent::init();
+                    $this->useLocalFs = false;
+                }
+
+                public function getRootUrl(): ?string
+                {
+                    return 'https://cdn.craft.cloud/assets/';
+                }
+            },
+        ]);
+    }
+}
+
+class UnsignedPdfImageAsset extends Asset
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->kind = self::KIND_PDF;
+    }
+
+    public function getUrl(mixed $transform = null, ?bool $immediately = null): ?string
+    {
+        return 'https://cdn.craft.cloud/assets/document.pdf?page=1&format=auto';
     }
 }
 

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -286,16 +286,28 @@ class ImageTransformTest extends Unit
                 ],
                 true,
             );
+
+            $invalidPageUrl = (new ImageTransformer())->getTransformUrl(
+                $this->makePdfAssetStub(),
+                [
+                    'transform' => 'thumb',
+                    'page' => 'foo',
+                ],
+                true,
+            );
         } finally {
             $transformsProperty->setValue($imageTransforms, $previousTransforms);
         }
 
         $parameters = Query::fromUri($signedUrl)->parameters();
+        $invalidPageParameters = Query::fromUri($invalidPageUrl)->parameters();
 
         $this->assertSame('320', $parameters['width']);
         $this->assertSame('320', $parameters['height']);
         $this->assertSame('2', $parameters['page']);
+        $this->assertArrayNotHasKey('page', $invalidPageParameters);
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
+        $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($invalidPageUrl));
     }
 
     public function testCloudGetImgDelegatesToNativeImageRendering(): void

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -283,7 +283,7 @@ class ImageTransformTest extends Unit
                 [
                     'transform' => 'thumb',
                     'page' => '2',
-                    'zoom' => 1.25,
+                    'zoom' => '1.25',
                 ],
                 true,
             );
@@ -305,6 +305,15 @@ class ImageTransformTest extends Unit
                 ],
                 true,
             );
+
+            $invalidZoomUrl = (new ImageTransformer())->getTransformUrl(
+                $this->makePdfAssetStub(),
+                [
+                    'transform' => 'thumb',
+                    'zoom' => 'foo',
+                ],
+                true,
+            );
         } finally {
             $transformsProperty->setValue($imageTransforms, $previousTransforms);
         }
@@ -312,6 +321,7 @@ class ImageTransformTest extends Unit
         $parameters = Query::fromUri($signedUrl)->parameters();
         $invalidPageParameters = Query::fromUri($invalidPageUrl)->parameters();
         $zeroPageParameters = Query::fromUri($zeroPageUrl)->parameters();
+        $invalidZoomParameters = Query::fromUri($invalidZoomUrl)->parameters();
 
         $this->assertSame('320', $parameters['width']);
         $this->assertSame('320', $parameters['height']);
@@ -319,9 +329,11 @@ class ImageTransformTest extends Unit
         $this->assertSame('1.25', $parameters['zoom']);
         $this->assertArrayNotHasKey('page', $invalidPageParameters);
         $this->assertArrayNotHasKey('page', $zeroPageParameters);
+        $this->assertArrayNotHasKey('zoom', $invalidZoomParameters);
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($invalidPageUrl));
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($zeroPageUrl));
+        $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($invalidZoomUrl));
     }
 
     public function testCloudGetImgDelegatesToNativeImageRendering(): void

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -283,6 +283,7 @@ class ImageTransformTest extends Unit
                 [
                     'transform' => 'thumb',
                     'page' => '2',
+                    'zoom' => 1.25,
                 ],
                 true,
             );
@@ -315,6 +316,7 @@ class ImageTransformTest extends Unit
         $this->assertSame('320', $parameters['width']);
         $this->assertSame('320', $parameters['height']);
         $this->assertSame('2', $parameters['page']);
+        $this->assertSame('1.25', $parameters['zoom']);
         $this->assertArrayNotHasKey('page', $invalidPageParameters);
         $this->assertArrayNotHasKey('page', $zeroPageParameters);
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -244,7 +244,7 @@ class ImageTransformTest extends Unit
                 'height' => 480.4,
                 'format' => 'webp',
                 'mode' => 'fit',
-                'page' => 2,
+                'page' => '2',
                 'upscale' => false,
             ],
             true,
@@ -282,7 +282,7 @@ class ImageTransformTest extends Unit
                 $this->makePdfAssetStub(),
                 [
                     'transform' => 'thumb',
-                    'page' => 2,
+                    'page' => '2',
                 ],
                 true,
             );
@@ -314,7 +314,7 @@ class ImageTransformTest extends Unit
     public function testCloudGetImgRendersSignedPdfTransform(): void
     {
         $transform = [
-            'page' => 1,
+            'page' => '1',
             'width' => 320,
             'height' => 240,
         ];

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -314,6 +314,16 @@ class ImageTransformTest extends Unit
                 ],
                 true,
             );
+
+            $invalidTypedOptionsUrl = (new ImageTransformer())->getTransformUrl(
+                $this->makePdfAssetStub(),
+                [
+                    'border' => 'red',
+                    'metadata' => 123,
+                    'transform' => 'thumb',
+                ],
+                true,
+            );
         } finally {
             $transformsProperty->setValue($imageTransforms, $previousTransforms);
         }
@@ -322,6 +332,7 @@ class ImageTransformTest extends Unit
         $invalidPageParameters = Query::fromUri($invalidPageUrl)->parameters();
         $zeroPageParameters = Query::fromUri($zeroPageUrl)->parameters();
         $invalidZoomParameters = Query::fromUri($invalidZoomUrl)->parameters();
+        $invalidTypedOptionsParameters = Query::fromUri($invalidTypedOptionsUrl)->parameters();
 
         $this->assertSame('320', $parameters['width']);
         $this->assertSame('320', $parameters['height']);
@@ -330,10 +341,13 @@ class ImageTransformTest extends Unit
         $this->assertArrayNotHasKey('page', $invalidPageParameters);
         $this->assertArrayNotHasKey('page', $zeroPageParameters);
         $this->assertArrayNotHasKey('zoom', $invalidZoomParameters);
+        $this->assertArrayNotHasKey('border', $invalidTypedOptionsParameters);
+        $this->assertArrayNotHasKey('metadata', $invalidTypedOptionsParameters);
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($invalidPageUrl));
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($zeroPageUrl));
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($invalidZoomUrl));
+        $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($invalidTypedOptionsUrl));
     }
 
     public function testCloudGetImgDelegatesToNativeImageRendering(): void
@@ -355,6 +369,7 @@ class ImageTransformTest extends Unit
             'page' => '1',
             'width' => 320,
             'height' => 240,
+            'zoom' => 'foo',
         ];
 
         $img = (new CloudVariable())->getImg(new SignedPdfImageAsset(), $transform);
@@ -368,6 +383,7 @@ class ImageTransformTest extends Unit
         $this->assertStringContainsString('/tests/document.pdf?', $src);
         $this->assertSame('auto', $parameters['format']);
         $this->assertSame('1', $parameters['page']);
+        $this->assertArrayNotHasKey('zoom', $parameters);
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($src));
     }
 

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -295,19 +295,31 @@ class ImageTransformTest extends Unit
                 ],
                 true,
             );
+
+            $zeroPageUrl = (new ImageTransformer())->getTransformUrl(
+                $this->makePdfAssetStub(),
+                [
+                    'transform' => 'thumb',
+                    'page' => '0',
+                ],
+                true,
+            );
         } finally {
             $transformsProperty->setValue($imageTransforms, $previousTransforms);
         }
 
         $parameters = Query::fromUri($signedUrl)->parameters();
         $invalidPageParameters = Query::fromUri($invalidPageUrl)->parameters();
+        $zeroPageParameters = Query::fromUri($zeroPageUrl)->parameters();
 
         $this->assertSame('320', $parameters['width']);
         $this->assertSame('320', $parameters['height']);
         $this->assertSame('2', $parameters['page']);
         $this->assertArrayNotHasKey('page', $invalidPageParameters);
+        $this->assertArrayNotHasKey('page', $zeroPageParameters);
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($invalidPageUrl));
+        $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($zeroPageUrl));
     }
 
     public function testCloudGetImgDelegatesToNativeImageRendering(): void

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -5,6 +5,7 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\base\FsInterface;
+use craft\base\MemoizableArray;
 use craft\cloud\fs\AssetsFs;
 use craft\cloud\imagetransforms\ImageTransformBehavior;
 use craft\cloud\imagetransforms\ImageTransformer;
@@ -255,6 +256,44 @@ class ImageTransformTest extends Unit
         $this->assertSame('640', $parameters['width']);
         $this->assertSame('480', $parameters['height']);
         $this->assertSame('scale-down', $parameters['fit']);
+        $this->assertSame('2', $parameters['page']);
+        $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
+    }
+
+    public function testPdfTransformUrlPreservesPageWhenExtendingNamedTransform(): void
+    {
+        $imageTransforms = Craft::$app->getImageTransforms();
+        $transformsProperty = new ReflectionProperty($imageTransforms, '_transforms');
+        $transformsProperty->setAccessible(true);
+        $previousTransforms = $transformsProperty->getValue($imageTransforms);
+
+        try {
+            $transformsProperty->setValue($imageTransforms, new MemoizableArray([
+                new ImageTransform([
+                    'name' => 'Thumb',
+                    'handle' => 'thumb',
+                    'width' => 320,
+                    'height' => 320,
+                    'mode' => 'crop',
+                ]),
+            ]));
+
+            $signedUrl = (new ImageTransformer())->getTransformUrl(
+                $this->makePdfAssetStub(),
+                [
+                    'transform' => 'thumb',
+                    'page' => 2,
+                ],
+                true,
+            );
+        } finally {
+            $transformsProperty->setValue($imageTransforms, $previousTransforms);
+        }
+
+        $parameters = Query::fromUri($signedUrl)->parameters();
+
+        $this->assertSame('320', $parameters['width']);
+        $this->assertSame('320', $parameters['height']);
         $this->assertSame('2', $parameters['page']);
         $this->assertTrue(CloudModule::getInstance()->getUrlSigner()->verify($signedUrl));
     }

--- a/tests/unit/ImageTransformTest.php
+++ b/tests/unit/ImageTransformTest.php
@@ -291,7 +291,7 @@ class ImageTransformTest extends Unit
                 $this->makePdfAssetStub(),
                 [
                     'transform' => 'thumb',
-                    'page' => 'foo',
+                    'page' => '1.5',
                 ],
                 true,
             );


### PR DESCRIPTION
Adds a Cloud Twig helper for rendering signed PDF transform URLs as `<img>` markup without changing Craft’s normal image gates.