### PR TITLE
Clarify asset repair commands

### DIFF
--- a/src/cli/controllers/AssetsController.php
+++ b/src/cli/controllers/AssetsController.php
@@ -34,11 +34,16 @@ class AssetsController extends Controller
     {
         return array_merge(parent::options($actionID), match ($actionID) {
             'replace-metadata',
-            'repair-metadata',
+            'repair',
             'missing',
             'metadata' => ['volume', 'assetId'],
             default => []
         });
+    }
+
+    public function actionRepair(): int
+    {
+        return $this->repairMissingAssetData();
     }
 
     protected function repairMissingAssetData(): int
@@ -110,7 +115,7 @@ class AssetsController extends Controller
         return ExitCode::OK;
     }
 
-    public function actionRepairMetadata(): int
+    protected function repairAssetObjectMetadataForAssets(): int
     {
         $assets = Asset::find()
             ->volume($this->volume)
@@ -134,7 +139,7 @@ class AssetsController extends Controller
             Console::FG_YELLOW,
         );
 
-        return $this->actionRepairMetadata();
+        return $this->repairAssetObjectMetadataForAssets();
     }
 
     /**

--- a/src/cli/controllers/assets/AssetRepairTrait.php
+++ b/src/cli/controllers/assets/AssetRepairTrait.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace craft\cloud\cli\controllers;
+namespace craft\cloud\cli\controllers\assets;
 
 use Craft;
 use craft\cloud\fs\Fs;
-use craft\console\Controller;
 use craft\db\Table;
 use craft\elements\Asset;
 use craft\helpers\FileHelper;
@@ -13,13 +12,8 @@ use yii\base\Exception;
 use yii\console\ExitCode;
 use yii\helpers\Console;
 
-class AssetsController extends Controller
+trait AssetRepairTrait
 {
-    private const CRAFT_STREAM_DIMENSION_FIX_VERSION = [
-        '4' => '4.18.4',
-        '5' => '5.10.9',
-    ];
-
     /**
      * @var array<string>|null
      */
@@ -33,17 +27,11 @@ class AssetsController extends Controller
     public function options($actionID): array
     {
         return array_merge(parent::options($actionID), match ($actionID) {
-            'replace-metadata',
-            'repair',
+            'index',
             'missing',
             'metadata' => ['volume', 'assetId'],
             default => []
         });
-    }
-
-    public function actionRepair(): int
-    {
-        return $this->repairMissingAssetData();
     }
 
     protected function repairMissingAssetData(): int
@@ -132,16 +120,6 @@ class AssetsController extends Controller
         return ExitCode::OK;
     }
 
-    public function actionReplaceMetadata(): int
-    {
-        $this->stdout(
-            'Deprecated: use `cloud/assets/repair/metadata` to repair object metadata instead.' . PHP_EOL,
-            Console::FG_YELLOW,
-        );
-
-        return $this->repairAssetObjectMetadataForAssets();
-    }
-
     /**
      * @return array{int,int}|null
      */
@@ -204,7 +182,7 @@ class AssetsController extends Controller
     protected function warnIfCraftStreamDimensionFixMissing(): void
     {
         $craftVersion = Craft::$app->getVersion();
-        $fixedVersion = self::CRAFT_STREAM_DIMENSION_FIX_VERSION[explode('.', $craftVersion)[0] ?? ''] ?? null;
+        $fixedVersion = $this->fixedCraftStreamDimensionVersion($craftVersion);
 
         if ($fixedVersion === null || version_compare($craftVersion, $fixedVersion, '>=')) {
             return;
@@ -232,5 +210,13 @@ class AssetsController extends Controller
         ];
 
         $fs->replaceMetadata($path, $config);
+    }
+
+    private function fixedCraftStreamDimensionVersion(string $craftVersion): ?string
+    {
+        return [
+            '4' => '4.18.4',
+            '5' => '5.10.9',
+        ][explode('.', $craftVersion)[0] ?? ''] ?? null;
     }
 }

--- a/src/cli/controllers/assets/RepairController.php
+++ b/src/cli/controllers/assets/RepairController.php
@@ -6,8 +6,6 @@ use craft\cloud\cli\controllers\AssetsController;
 
 class RepairController extends AssetsController
 {
-    public $defaultAction = 'missing';
-
     public function createAction($id)
     {
         if (!in_array($id, ['missing', 'metadata'], true)) {

--- a/src/cli/controllers/assets/RepairController.php
+++ b/src/cli/controllers/assets/RepairController.php
@@ -2,18 +2,13 @@
 
 namespace craft\cloud\cli\controllers\assets;
 
-use craft\cloud\cli\controllers\AssetsController;
+use craft\console\Controller;
 
-class RepairController extends AssetsController
+class RepairController extends Controller
 {
-    public function createAction($id)
-    {
-        if (!in_array($id, ['missing', 'metadata'], true)) {
-            return null;
-        }
+    use AssetRepairTrait;
 
-        return parent::createAction($id);
-    }
+    public $defaultAction = 'missing';
 
     public function actionMissing(): int
     {

--- a/src/cli/controllers/assets/RepairController.php
+++ b/src/cli/controllers/assets/RepairController.php
@@ -24,6 +24,6 @@ class RepairController extends AssetsController
 
     public function actionMetadata(): int
     {
-        return $this->actionRepairMetadata();
+        return $this->repairAssetObjectMetadataForAssets();
     }
 }

--- a/src/cli/controllers/assets/ReplaceMetadataController.php
+++ b/src/cli/controllers/assets/ReplaceMetadataController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace craft\cloud\cli\controllers\assets;
+
+use craft\console\Controller;
+use yii\helpers\Console;
+
+class ReplaceMetadataController extends Controller
+{
+    use AssetRepairTrait;
+
+    public function actionIndex(): int
+    {
+        $this->stdout(
+            'Deprecated: use `cloud/assets/repair/metadata` to repair object metadata instead.' . PHP_EOL,
+            Console::FG_YELLOW,
+        );
+
+        return $this->repairAssetObjectMetadataForAssets();
+    }
+}

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -128,43 +128,14 @@ class AssetsControllerTest extends Unit
         $this->assertSame(0, $fs->streamReadCount);
     }
 
-    public function testCliAssetsRepairCommandDefaultsToMissingDataRepair(): void
-    {
-        $controller = new RepairController('assets/repair', Craft::$app);
-
-        $this->assertSame('missing', $controller->defaultAction);
-        $this->assertNotNull($controller->createAction($controller->defaultAction));
-    }
-
-    public function testCliAssetsRepairCommandExposesRepairActions(): void
-    {
-        $controller = new RepairController('assets/repair', Craft::$app);
-
-        $this->assertNotNull($controller->createAction('missing'));
-        $this->assertNotNull($controller->createAction('metadata'));
-        $this->assertNull($controller->createAction('replace-metadata'));
-        $this->assertNull($controller->createAction('repair-metadata'));
-    }
-
     public function testCliAssetsRepairRoutesResolveThroughYiiModule(): void
     {
         $module = new BaseModule('cloud');
         $module->controllerNamespace = 'craft\\cloud\\cli\\controllers';
 
-        $result = $module->createController('assets/repair');
-
-        $this->assertIsArray($result);
-        [$controller, $actionId] = $result;
-        $this->assertInstanceOf(CliAssetsController::class, $controller);
-        $this->assertSame('repair', $actionId);
-        $this->assertNotNull($controller->createAction($actionId));
-
-        $result = $module->createController('assets/repair/metadata');
-
-        $this->assertIsArray($result);
-        [$controller, $actionId] = $result;
-        $this->assertInstanceOf(RepairController::class, $controller);
-        $this->assertSame('metadata', $actionId);
+        $this->assertCliRoute($module, 'assets/repair', CliAssetsController::class, 'repair');
+        $this->assertCliRoute($module, 'assets/repair/missing', RepairController::class, 'missing');
+        $this->assertCliRoute($module, 'assets/repair/metadata', RepairController::class, 'metadata');
     }
 
     public function testCliAssetsCommandExposesRepairEntryAndDeprecatedReplaceAlias(): void
@@ -185,6 +156,21 @@ class AssetsControllerTest extends Unit
         $method->setAccessible(true);
 
         return $method->invoke($controller, $volume);
+    }
+
+    /**
+     * @param class-string $controllerClass
+     */
+    private function assertCliRoute(BaseModule $module, string $route, string $controllerClass, string $actionId): void
+    {
+        $result = $module->createController($route);
+
+        $this->assertIsArray($result);
+
+        [$controller, $resolvedActionId] = $result;
+        $this->assertInstanceOf($controllerClass, $controller);
+        $this->assertSame($actionId, $resolvedActionId);
+        $this->assertNotNull($controller->createAction($resolvedActionId));
     }
 }
 

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -4,11 +4,14 @@ namespace craft\cloud\tests\unit;
 
 use Codeception\Test\Unit;
 use Craft;
+use craft\cloud\cli\controllers\assets\RepairController;
+use craft\cloud\cli\controllers\AssetsController as CliAssetsController;
 use craft\cloud\controllers\AssetsController;
 use craft\cloud\fs\Fs;
 use craft\elements\Asset;
 use craft\models\Volume;
 use ReflectionMethod;
+use yii\base\Module as BaseModule;
 use yii\web\BadRequestHttpException;
 
 class AssetsControllerTest extends Unit
@@ -123,6 +126,56 @@ class AssetsControllerTest extends Unit
         $this->assertNull($fs->getImageDimensions('upload.jpeg'));
         $this->assertSame(4, $fs->readCount);
         $this->assertSame(0, $fs->streamReadCount);
+    }
+
+    public function testCliAssetsRepairCommandDefaultsToMissingDataRepair(): void
+    {
+        $controller = new RepairController('assets/repair', Craft::$app);
+
+        $this->assertSame('missing', $controller->defaultAction);
+        $this->assertNotNull($controller->createAction($controller->defaultAction));
+    }
+
+    public function testCliAssetsRepairCommandExposesRepairActions(): void
+    {
+        $controller = new RepairController('assets/repair', Craft::$app);
+
+        $this->assertNotNull($controller->createAction('missing'));
+        $this->assertNotNull($controller->createAction('metadata'));
+        $this->assertNull($controller->createAction('replace-metadata'));
+        $this->assertNull($controller->createAction('repair-metadata'));
+    }
+
+    public function testCliAssetsRepairRoutesResolveThroughYiiModule(): void
+    {
+        $module = new BaseModule('cloud');
+        $module->controllerNamespace = 'craft\\cloud\\cli\\controllers';
+
+        $result = $module->createController('assets/repair');
+
+        $this->assertIsArray($result);
+        [$controller, $actionId] = $result;
+        $this->assertInstanceOf(CliAssetsController::class, $controller);
+        $this->assertSame('repair', $actionId);
+        $this->assertNotNull($controller->createAction($actionId));
+
+        $result = $module->createController('assets/repair/metadata');
+
+        $this->assertIsArray($result);
+        [$controller, $actionId] = $result;
+        $this->assertInstanceOf(RepairController::class, $controller);
+        $this->assertSame('metadata', $actionId);
+    }
+
+    public function testCliAssetsCommandExposesRepairEntryAndDeprecatedReplaceAlias(): void
+    {
+        $controller = new CliAssetsController('assets', Craft::$app);
+
+        $this->assertNotNull($controller->createAction('repair'));
+        $this->assertNotNull($controller->createAction('replace-metadata'));
+        $this->assertNull($controller->createAction('missing'));
+        $this->assertNull($controller->createAction('metadata'));
+        $this->assertNull($controller->createAction('repair-metadata'));
     }
 
     private function invokeVolumeSubpath(Volume $volume): string

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -5,9 +5,10 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\cli\controllers\assets\RepairController;
-use craft\cloud\cli\controllers\AssetsController as CliAssetsController;
+use craft\cloud\cli\controllers\assets\ReplaceMetadataController;
 use craft\cloud\controllers\AssetsController;
 use craft\cloud\fs\Fs;
+use craft\console\Controller as ConsoleController;
 use craft\elements\Asset;
 use craft\models\Volume;
 use ReflectionMethod;
@@ -133,20 +134,29 @@ class AssetsControllerTest extends Unit
         $module = new BaseModule('cloud');
         $module->controllerNamespace = 'craft\\cloud\\cli\\controllers';
 
-        $this->assertCliRoute($module, 'assets/repair', CliAssetsController::class, 'repair');
+        $this->assertCliRoute($module, 'assets/repair', RepairController::class, '', 'missing');
         $this->assertCliRoute($module, 'assets/repair/missing', RepairController::class, 'missing');
         $this->assertCliRoute($module, 'assets/repair/metadata', RepairController::class, 'metadata');
+        $this->assertCliRoute($module, 'assets/replace-metadata', ReplaceMetadataController::class, '', 'index');
     }
 
-    public function testCliAssetsCommandExposesRepairEntryAndDeprecatedReplaceAlias(): void
+    public function testCliAssetsCommandsDoNotExposeTopLevelOrUnreleasedRoutes(): void
     {
-        $controller = new CliAssetsController('assets', Craft::$app);
+        $module = new BaseModule('cloud');
+        $module->controllerNamespace = 'craft\\cloud\\cli\\controllers';
 
-        $this->assertNotNull($controller->createAction('repair'));
-        $this->assertNotNull($controller->createAction('replace-metadata'));
-        $this->assertNull($controller->createAction('missing'));
-        $this->assertNull($controller->createAction('metadata'));
-        $this->assertNull($controller->createAction('repair-metadata'));
+        $this->assertFalse($module->createController('assets'));
+        $this->assertFalse($module->createController('assets/repair-metadata'));
+    }
+
+    public function testCliAssetsCommandsExposeAssetFilters(): void
+    {
+        $repairController = new RepairController('assets/repair', Craft::$app);
+        $replaceMetadataController = new ReplaceMetadataController('assets/replace-metadata', Craft::$app);
+
+        $this->assertCliAssetFilterOptions($repairController, 'missing');
+        $this->assertCliAssetFilterOptions($repairController, 'metadata');
+        $this->assertCliAssetFilterOptions($replaceMetadataController, 'index');
     }
 
     private function invokeVolumeSubpath(Volume $volume): string
@@ -161,8 +171,13 @@ class AssetsControllerTest extends Unit
     /**
      * @param class-string $controllerClass
      */
-    private function assertCliRoute(BaseModule $module, string $route, string $controllerClass, string $actionId): void
-    {
+    private function assertCliRoute(
+        BaseModule $module,
+        string $route,
+        string $controllerClass,
+        string $actionId,
+        ?string $effectiveActionId = null,
+    ): void {
         $result = $module->createController($route);
 
         $this->assertIsArray($result);
@@ -170,7 +185,19 @@ class AssetsControllerTest extends Unit
         [$controller, $resolvedActionId] = $result;
         $this->assertInstanceOf($controllerClass, $controller);
         $this->assertSame($actionId, $resolvedActionId);
-        $this->assertNotNull($controller->createAction($resolvedActionId));
+
+        $action = $controller->createAction($resolvedActionId);
+
+        $this->assertNotNull($action);
+        $this->assertSame($effectiveActionId ?? $actionId, $action->id);
+    }
+
+    private function assertCliAssetFilterOptions(ConsoleController $controller, string $actionId): void
+    {
+        $options = $controller->options($actionId);
+
+        $this->assertContains('volume', $options);
+        $this->assertContains('assetId', $options);
     }
 }
 


### PR DESCRIPTION
Compared with the latest tag (`3.6.0`), this keeps the only released asset metadata repair command (`cloud/assets/replace-metadata`) working as a deprecated alias while grouping the new repair commands under `cloud/assets/repair/*`.