### PR TITLE
Repair dimensions for volume subpaths

### DIFF
--- a/src/cli/controllers/assets/AssetRepairTrait.php
+++ b/src/cli/controllers/assets/AssetRepairTrait.php
@@ -4,6 +4,7 @@ namespace craft\cloud\cli\controllers\assets;
 
 use Craft;
 use craft\cloud\fs\Fs;
+use craft\cloud\traits\VolumeSubpathTrait;
 use craft\db\Table;
 use craft\elements\Asset;
 use craft\helpers\FileHelper;
@@ -14,6 +15,8 @@ use yii\helpers\Console;
 
 trait AssetRepairTrait
 {
+    use VolumeSubpathTrait;
+
     /**
      * @var array<string>|null
      */
@@ -132,7 +135,7 @@ trait AssetRepairTrait
             return null;
         }
 
-        $path = (method_exists($volume, 'getSubpath') ? $volume->getSubpath() : '') . $asset->getPath();
+        $path = $this->volumeSubpath($volume) . $asset->getPath();
         $dimensions = $fs->getImageDimensions($path);
 
         if ($dimensions === null || !$dimensions[0] || !$dimensions[1]) {

--- a/src/cli/controllers/assets/AssetRepairTrait.php
+++ b/src/cli/controllers/assets/AssetRepairTrait.php
@@ -125,13 +125,15 @@ trait AssetRepairTrait
      */
     protected function repairAssetDimensions(Asset $asset): ?array
     {
-        $fs = $asset->getVolume()->getFs();
+        $volume = $asset->getVolume();
+        $fs = $volume->getFs();
 
         if (!$fs instanceof Fs) {
             return null;
         }
 
-        $dimensions = $fs->getImageDimensions($asset->getPath());
+        $path = (method_exists($volume, 'getSubpath') ? $volume->getSubpath() : '') . $asset->getPath();
+        $dimensions = $fs->getImageDimensions($path);
 
         if ($dimensions === null || !$dimensions[0] || !$dimensions[1]) {
             return null;

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -418,12 +418,13 @@ class AssetsController extends Controller
 
     protected function uploadedImageDimensions(Asset $asset, string $filename): array
     {
-        $fs = $asset->getVolume()->getFs();
+        $volume = $asset->getVolume();
+        $fs = $volume->getFs();
 
         // Null dimensions are safer than browser-oriented dimensions for EXIF
         // images, but they can still prevent image-editor use until reindexed.
         return $fs instanceof Fs
-            ? $fs->getImageDimensions($asset->getPath($filename)) ?? [null, null]
+            ? $fs->getImageDimensions($this->volumeSubpath($volume) . $asset->getPath($filename)) ?? [null, null]
             : [null, null];
     }
 

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -4,6 +4,7 @@ namespace craft\cloud\controllers;
 
 use Craft;
 use craft\cloud\fs\Fs;
+use craft\cloud\traits\VolumeSubpathTrait;
 use craft\controllers\AssetsControllerTrait;
 use craft\elements\Asset;
 use craft\elements\conditions\ElementCondition;
@@ -11,7 +12,6 @@ use craft\events\ReplaceAssetEvent;
 use craft\fields\Assets as AssetsField;
 use craft\helpers\Assets;
 use craft\helpers\Db;
-use craft\models\Volume;
 use craft\web\Controller;
 use DateTime;
 use Throwable;
@@ -25,6 +25,7 @@ use yii\web\Response;
 class AssetsController extends Controller
 {
     use AssetsControllerTrait;
+    use VolumeSubpathTrait;
 
     public function actionGetUploadUrl(): Response
     {
@@ -382,11 +383,6 @@ class AssetsController extends Controller
         });
 
         return Craft::$app->getElements()->saveElement($asset);
-    }
-
-    private function volumeSubpath(Volume $volume): string
-    {
-        return method_exists($volume, 'getSubpath') ? $volume->getSubpath() : '';
     }
 
     protected function setUploadedAssetMetadata(Asset $asset, string $filename, ?string $displayFilename = null): void

--- a/src/traits/VolumeSubpathTrait.php
+++ b/src/traits/VolumeSubpathTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace craft\cloud\traits;
+
+use craft\models\Volume;
+
+trait VolumeSubpathTrait
+{
+    private function volumeSubpath(Volume $volume): string
+    {
+        return method_exists($volume, 'getSubpath') ? $volume->getSubpath() : '';
+    }
+}

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -53,7 +53,13 @@ class AssetsControllerTest extends Unit
         $fs->header = "\xFF\xD8"
             . "\xFF\xE1" . pack('n', 4) . 'xx'
             . "\xFF\xC0" . pack('n', 17) . "\x08" . pack('n', 3024) . pack('n', 4032) . str_repeat("\0", 10);
-        $asset = new TestAsset(new TestVolume(123, $fs));
+        $volume = new TestVolume(123, $fs);
+
+        if (method_exists($volume, 'setSubpath')) {
+            $volume->setSubpath('volume-prefix');
+        }
+
+        $asset = new TestAsset($volume);
         $asset->setFilename('upload.jpeg');
         $asset->kind = Asset::KIND_IMAGE;
 
@@ -63,6 +69,7 @@ class AssetsControllerTest extends Unit
         $this->assertSame(4032, $asset->getWidth());
         $this->assertSame(3024, $asset->getHeight());
         $this->assertSame(1, $fs->readCount);
+        $this->assertSame([method_exists($volume, 'getSubpath') ? 'volume-prefix/upload.jpeg' : 'upload.jpeg'], $fs->requestedPaths);
     }
 
     public function testUploadedAssetMetadataLeavesUnreadableDimensionsNull(): void
@@ -159,6 +166,29 @@ class AssetsControllerTest extends Unit
         $this->assertCliAssetFilterOptions($replaceMetadataController, 'index');
     }
 
+    public function testRepairAssetDimensionsUsesVolumeSubpath(): void
+    {
+        if (!method_exists(new Volume(), 'setSubpath')) {
+            $this->markTestSkipped('Craft 4 volumes do not implement a subpath.');
+        }
+
+        $fs = new HeaderTestFs();
+        $fs->header = "\xFF\xD8"
+            . "\xFF\xE1" . pack('n', 4) . 'xx'
+            . "\xFF\xC0" . pack('n', 17) . "\x08" . pack('n', 3024) . pack('n', 4032) . str_repeat("\0", 10);
+        $volume = new TestVolume(123, $fs);
+        $volume->setSubpath('volume-prefix');
+        $asset = new TestAsset($volume);
+        $asset->setFilename('upload.jpeg');
+        $asset->setWidth(4032);
+        $asset->setHeight(3024);
+
+        $controller = new TestRepairController('assets/repair', Craft::$app);
+
+        $this->assertSame([4032, 3024], $controller->repairAssetDimensionsForTest($asset));
+        $this->assertSame(['volume-prefix/upload.jpeg'], $fs->requestedPaths);
+    }
+
     private function invokeVolumeSubpath(Volume $volume): string
     {
         $controller = new AssetsController('cloud-assets', Craft::$app);
@@ -231,6 +261,7 @@ class HeaderTestFs extends Fs
     public string $header;
     public array $headers = [];
     public int $readCount = 0;
+    public array $requestedPaths = [];
 
     public static function displayName(): string
     {
@@ -240,6 +271,7 @@ class HeaderTestFs extends Fs
     public function getFileStreamRange(string $uriPath, int $start, int $end)
     {
         $this->readCount++;
+        $this->requestedPaths[] = $uriPath;
 
         $stream = fopen('php://temp', 'r+');
 
@@ -281,6 +313,14 @@ class NullDimensionsTestFs extends HeaderTestFs
     public function getImageDimensions(string $uriPath): ?array
     {
         return null;
+    }
+}
+
+class TestRepairController extends RepairController
+{
+    public function repairAssetDimensionsForTest(Asset $asset): ?array
+    {
+        return $this->repairAssetDimensions($asset);
     }
 }
 


### PR DESCRIPTION
Keeps Cloud asset dimension reads aligned with Craft volume subpaths, so repairs and direct uploads inspect the correct source object.