### PR TITLE
Keep cache invalidations safe

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -250,7 +250,6 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
                 ->reject(fn(string $header) => $header === 'X-Forwarded-Host')
                 ->all();
 
-            // Important this gets called last so multi-value headers aren't prematurely joined
             (new ResponseEventHandler())->handle();
         }
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -236,7 +236,7 @@ class StaticCache extends \yii\base\Component
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->normalizeCacheTags(...$this->tags);
-        $cacheTags = $this->cacheTagsForHeader($this->tags);
+        $cacheTags = $this->prepareCacheTagsForHeader($this->tags);
 
         Craft::info(new PsrMessage('Adding cache tags to response', [
             'tags' => $cacheTags,
@@ -283,7 +283,7 @@ class StaticCache extends \yii\base\Component
         ]), __METHOD__);
 
         if ($isWebResponse) {
-            $tags = $this->cacheTagsForHeader($tags);
+            $tags = $this->prepareCacheTagsForHeader($tags);
 
             $response->getHeaders()->set(
                 HeaderEnum::CACHE_PURGE_TAG->value,
@@ -403,7 +403,7 @@ class StaticCache extends \yii\base\Component
             ->filter(fn(string $tag) => $tag !== '');
     }
 
-    private function cacheTagsForHeader(Collection $tags): Collection
+    private function prepareCacheTagsForHeader(Collection $tags): Collection
     {
         $headerTags = $this->truncateCacheTags($tags);
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -272,10 +272,7 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        $tags = $this->normalizeCacheTags(
-            $this->overflowTag(),
-            ...$tags,
-        );
+        $tags = $this->addOverflowTag($tags, $this->overflowTag());
 
         Craft::info(new PsrMessage('Purging tags', [
             'tags' => $tags,
@@ -394,10 +391,10 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function parseCacheTagsFromHeader(array $headers): Collection
+    private function parseCacheTagsFromHeader(array $headerValues): Collection
     {
-        return Collection::make($headers)
-            ->flatMap(fn(string $header) => explode(',', $header))
+        return Collection::make($headerValues)
+            ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
             ->map(fn(string $tag) => trim($tag))
             ->filter(fn(string $tag) => $tag !== '');
     }
@@ -412,7 +409,7 @@ class StaticCache extends \yii\base\Component
 
         $overflowTag = $this->overflowTag();
         $headerTags = $this->truncateCacheTags(
-            $this->normalizeCacheTags($overflowTag, ...$tags->values()->all()),
+            $this->addOverflowTag($tags, $overflowTag),
         );
 
         $inputTagCount = $tags
@@ -430,6 +427,14 @@ class StaticCache extends \yii\base\Component
         ]), __METHOD__);
 
         return $headerTags;
+    }
+
+    private function addOverflowTag(Collection $tags, StaticCacheTag $overflowTag): Collection
+    {
+        return $this->normalizeCacheTags(
+            $overflowTag,
+            ...$tags->values()->all(),
+        );
     }
 
     private function truncateCacheTags(Collection $tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -260,8 +260,6 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        $tags = $this->normalizeCacheTags($this->overflowTag(), ...$tags);
-
         Craft::info(new PsrMessage('Purging tags', [
             'tags' => $tags,
         ]), __METHOD__);

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -229,10 +229,7 @@ class StaticCache extends \yii\base\Component
             $this->staticCacheDirectives()->implode(','),
         );
 
-        $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? [])
-            ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
-            ->map(fn(string $tag) => trim($tag))
-            ->filter(fn(string $tag) => $tag !== '');
+        $existingTagsFromHeader = $this->parseCacheTagsFromHeader(HeaderEnum::CACHE_TAG->value);
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->normalizeCacheTags(...$this->tags);
@@ -253,13 +250,7 @@ class StaticCache extends \yii\base\Component
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $existingTagsFromHeader = Collection::make($response->getHeaders()->get(
-                HeaderEnum::CACHE_PURGE_TAG->value,
-                first: false,
-            ) ?? [])
-                ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
-                ->map(fn(string $tag) => trim($tag))
-                ->filter(fn(string $tag) => $tag !== '');
+            $existingTagsFromHeader = $this->parseCacheTagsFromHeader(HeaderEnum::CACHE_PURGE_TAG->value);
             $tags->push(...$existingTagsFromHeader);
             $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
         }
@@ -387,6 +378,14 @@ class StaticCache extends \yii\base\Component
             ->map(fn(string|StaticCacheTag $tag) => is_string($tag) ? StaticCacheTag::create($tag) : $tag)
             ->filter(fn(StaticCacheTag $tag) => $tag->getValue() !== '')
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
+    }
+
+    private function parseCacheTagsFromHeader(string $header): Collection
+    {
+        return Collection::make(Craft::$app->getResponse()->getHeaders()->get($header, first: false) ?? [])
+            ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
+            ->map(fn(string $tag) => trim($tag))
+            ->filter(fn(string $tag) => $tag !== '');
     }
 
     private function setCacheTagHeader(string $header, Collection $tags): void

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -46,7 +46,7 @@ class StaticCache extends \yii\base\Component
      *
      * @see https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
      */
-    private const CLOUDFLARE_MAX_CACHE_TAG_HEADER_VALUE_LENGTH = 16 * 1024;
+    private const MAX_CACHE_TAG_HEADER_VALUE_LENGTH = 16 * 1024;
     private ?int $cacheDuration = null;
     private Collection $tags;
     private Collection $tagsToPurge;
@@ -230,23 +230,26 @@ class StaticCache extends \yii\base\Component
         );
 
         // Capture and remove any existing headers, so we can prepare them
-        $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? []);
+        $existingTagsFromHeader = $this->splitCacheTagHeaders(
+            $headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? [],
+        );
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags->push(...$existingTagsFromHeader);
-        $this->tags = $this->prepareTags(...$this->tags);
-        $cacheTags = $this->limitCacheTags($this->tags);
+        $this->tags = $this->normalizeCacheTags(...$this->tags);
+        $cacheTags = $this->withOverflowTagIfNeeded($this->tags);
 
         Craft::info(new PsrMessage('Adding cache tags to response', [
             'tags' => $cacheTags,
         ]), __METHOD__);
 
-        $cacheTags
-            ->each(function(StaticCacheTag $tag) use ($headers) {
-                $headers->add(
-                    HeaderEnum::CACHE_TAG->value,
-                    $tag->getValue(),
-                );
-            });
+        if ($cacheTags->isEmpty()) {
+            return;
+        }
+
+        $headers->set(
+            HeaderEnum::CACHE_TAG->value,
+            $cacheTags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','),
+        );
     }
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
@@ -257,18 +260,20 @@ class StaticCache extends \yii\base\Component
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $existingTagsFromHeader = $response->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value, first: false) ?? [];
+            $existingTagsFromHeader = $this->splitCacheTagHeaders(
+                $response->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value, first: false) ?? [],
+            );
             $tags->push(...$existingTagsFromHeader);
             $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
         }
 
-        $tags = $this->prepareTags(...$tags);
+        $tags = $this->normalizeCacheTags(...$tags);
 
         if ($tags->isEmpty()) {
             return;
         }
 
-        $tags = $this->prepareTags(
+        $tags = $this->normalizeCacheTags(
             StaticCacheTag::create($this->overflowTag()),
             ...$tags,
         );
@@ -278,10 +283,12 @@ class StaticCache extends \yii\base\Component
         ]), __METHOD__);
 
         if ($isWebResponse) {
-            $tags->each(fn(StaticCacheTag $tag) => $response->getHeaders()->add(
+            $tags = $this->withOverflowTagIfNeeded($tags);
+
+            $response->getHeaders()->set(
                 HeaderEnum::CACHE_PURGE_TAG->value,
-                $tag->getValue(),
-            ));
+                $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','),
+            );
 
             return;
         }
@@ -380,7 +387,7 @@ class StaticCache extends \yii\base\Component
         }
     }
 
-    private function prepareTags(string|StaticCacheTag ...$tags): Collection
+    private function normalizeCacheTags(string|StaticCacheTag ...$tags): Collection
     {
         return Collection::make($tags)
             ->map(fn(string|StaticCacheTag $tag) => is_string($tag) ? StaticCacheTag::create($tag) : $tag)
@@ -388,33 +395,41 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function limitCacheTags(Collection $tags): Collection
+    private function splitCacheTagHeaders(array $headers): Collection
     {
-        $cacheTags = $this->takeCacheTagsThatFit($tags);
+        return Collection::make($headers)
+            ->flatMap(fn(string $header) => explode(',', $header));
+    }
+
+    private function withOverflowTagIfNeeded(Collection $tags): Collection
+    {
+        $cacheTags = $this->truncateCacheTags($tags);
 
         if ($cacheTags->count() === $tags->count()) {
             return $cacheTags;
         }
 
         $overflowTag = StaticCacheTag::create($this->overflowTag());
-        $cacheTags = $this->takeCacheTagsThatFit(
-            $this->prepareTags($overflowTag, ...$tags->values()->all()),
+        $cacheTags = $this->truncateCacheTags(
+            $this->normalizeCacheTags($overflowTag, ...$tags->values()->all()),
         );
+        $totalTagCount = $tags
+            ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
+            ->count();
         $exactTagCount = $cacheTags
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
             ->count();
 
-        Craft::warning(new PsrMessage('Cache tags exceed Cloudflare’s maximum header value length; using overflow tag', [
-            'emittedTags' => $cacheTags->count(),
-            'droppedTags' => $tags->count() - $exactTagCount,
-            'cloudflareMaxCacheTagHeaderValueLength' => self::CLOUDFLARE_MAX_CACHE_TAG_HEADER_VALUE_LENGTH,
+        Craft::warning(new PsrMessage('Cache tags exceed the maximum header value length; using overflow tag', [
+            'totalTags' => $totalTagCount,
+            'truncatedTags' => $totalTagCount - $exactTagCount,
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
 
         return $cacheTags;
     }
 
-    private function takeCacheTagsThatFit(Collection $tags): Collection
+    private function truncateCacheTags(Collection $tags): Collection
     {
         $headerValue = '';
 
@@ -422,7 +437,7 @@ class StaticCache extends \yii\base\Component
             $value = $tag->getValue();
             $newHeaderValue = $headerValue === '' ? $value : "$headerValue,$value";
 
-            if (StringHelper::byteLength($newHeaderValue) > self::CLOUDFLARE_MAX_CACHE_TAG_HEADER_VALUE_LENGTH) {
+            if (StringHelper::byteLength($newHeaderValue) > self::MAX_CACHE_TAG_HEADER_VALUE_LENGTH) {
                 return false;
             }
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -230,7 +230,7 @@ class StaticCache extends \yii\base\Component
         );
 
         // Capture and remove any existing headers, so we can prepare them
-        $existingTagsFromHeader = $this->splitCacheTagHeaders(
+        $existingTagsFromHeader = $this->parseCacheTagHeaders(
             $headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? [],
         );
         $headers->remove(HeaderEnum::CACHE_TAG->value);
@@ -260,7 +260,7 @@ class StaticCache extends \yii\base\Component
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $existingTagsFromHeader = $this->splitCacheTagHeaders(
+            $existingTagsFromHeader = $this->parseCacheTagHeaders(
                 $response->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value, first: false) ?? [],
             );
             $tags->push(...$existingTagsFromHeader);
@@ -395,7 +395,7 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function splitCacheTagHeaders(array $headers): Collection
+    private function parseCacheTagHeaders(array $headers): Collection
     {
         return Collection::make($headers)
             ->flatMap(fn(string $header) => explode(',', $header))

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -21,6 +21,7 @@ use League\Uri\Components\Path;
 use samdark\log\PsrMessage;
 use yii\base\Event;
 use yii\caching\TagDependency;
+use yii\web\HeaderCollection;
 
 /**
  * Static Cache tags can appear in the `Cache-Tag` and `Cache-Purge-Tag` headers.
@@ -229,9 +230,7 @@ class StaticCache extends \yii\base\Component
             $this->staticCacheDirectives()->implode(','),
         );
 
-        $existingTagsFromHeader = $this->parseCacheTagsFromHeader(
-            $headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? [],
-        );
+        $existingTagsFromHeader = $this->parseCacheTagsFromHeader(HeaderEnum::CACHE_TAG, $headers);
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->normalizeCacheTags(...$this->tags);
@@ -241,14 +240,7 @@ class StaticCache extends \yii\base\Component
             'tags' => $cacheTags,
         ]), __METHOD__);
 
-        if ($cacheTags->isEmpty()) {
-            return;
-        }
-
-        $headers->set(
-            HeaderEnum::CACHE_TAG->value,
-            $cacheTags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','),
-        );
+        $this->setCacheTagsHeader(HeaderEnum::CACHE_TAG, $headers, $cacheTags);
     }
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
@@ -260,7 +252,8 @@ class StaticCache extends \yii\base\Component
         // Add any existing tags from the response headers
         if ($isWebResponse) {
             $existingTagsFromHeader = $this->parseCacheTagsFromHeader(
-                $response->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value, first: false) ?? [],
+                HeaderEnum::CACHE_PURGE_TAG,
+                $response->getHeaders(),
             );
             $tags->push(...$existingTagsFromHeader);
             $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
@@ -281,10 +274,7 @@ class StaticCache extends \yii\base\Component
         if ($isWebResponse) {
             $tags = $this->prepareCacheTagsForHeader($tags);
 
-            $response->getHeaders()->set(
-                HeaderEnum::CACHE_PURGE_TAG->value,
-                $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','),
-            );
+            $this->setCacheTagsHeader(HeaderEnum::CACHE_PURGE_TAG, $response->getHeaders(), $tags);
 
             return;
         }
@@ -391,12 +381,24 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function parseCacheTagsFromHeader(array $headerValues): Collection
+    private function parseCacheTagsFromHeader(HeaderEnum $header, HeaderCollection $headers): Collection
     {
-        return Collection::make($headerValues)
+        return Collection::make($headers->get($header->value, first: false) ?? [])
             ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
             ->map(fn(string $tag) => trim($tag))
             ->filter(fn(string $tag) => $tag !== '');
+    }
+
+    private function setCacheTagsHeader(HeaderEnum $header, HeaderCollection $headers, Collection $tags): void
+    {
+        if ($tags->isEmpty()) {
+            return;
+        }
+
+        $headers->set(
+            $header->value,
+            $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','),
+        );
     }
 
     private function prepareCacheTagsForHeader(Collection $tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -230,7 +230,7 @@ class StaticCache extends \yii\base\Component
             $this->staticCacheDirectives()->implode(','),
         );
 
-        $existingTagsFromHeader = $this->parseCacheTagsFromHeader(HeaderEnum::CACHE_TAG, $headers);
+        $existingTagsFromHeader = $this->parseCacheTagsFromHeaders(HeaderEnum::CACHE_TAG->value, $headers);
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->normalizeCacheTags(...$this->tags);
@@ -251,8 +251,8 @@ class StaticCache extends \yii\base\Component
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $existingTagsFromHeader = $this->parseCacheTagsFromHeader(
-                HeaderEnum::CACHE_PURGE_TAG,
+            $existingTagsFromHeader = $this->parseCacheTagsFromHeaders(
+                HeaderEnum::CACHE_PURGE_TAG->value,
                 $response->getHeaders(),
             );
             $tags->push(...$existingTagsFromHeader);
@@ -381,9 +381,9 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function parseCacheTagsFromHeader(HeaderEnum $header, HeaderCollection $headers): Collection
+    private function parseCacheTagsFromHeaders(string $header, HeaderCollection $headers): Collection
     {
-        return Collection::make($headers->get($header->value, first: false) ?? [])
+        return Collection::make($headers->get($header, first: false) ?? [])
             ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
             ->map(fn(string $tag) => trim($tag))
             ->filter(fn(string $tag) => $tag !== '');

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -441,17 +441,18 @@ class StaticCache extends \yii\base\Component
 
     private function truncateCacheTags(Collection $tags): Collection
     {
-        $headerValue = '';
+        $headerValueLength = 0;
 
-        return $tags->filter(function(StaticCacheTag $tag) use (&$headerValue) {
+        return $tags->filter(function(StaticCacheTag $tag) use (&$headerValueLength) {
             $value = $tag->getValue();
-            $newHeaderValue = $headerValue === '' ? $value : "$headerValue,$value";
+            $separatorLength = $headerValueLength === 0 ? 0 : 1;
+            $newHeaderValueLength = $headerValueLength + $separatorLength + StringHelper::byteLength($value);
 
-            if (StringHelper::byteLength($newHeaderValue) > self::MAX_HEADER_VALUE_LENGTH) {
+            if ($newHeaderValueLength > self::MAX_HEADER_VALUE_LENGTH) {
                 return false;
             }
 
-            $headerValue = $newHeaderValue;
+            $headerValueLength = $newHeaderValueLength;
 
             return true;
         });

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -9,6 +9,7 @@ use craft\events\InvalidateElementCachesEvent;
 use craft\events\RegisterCacheOptionsEvent;
 use craft\events\TemplateEvent;
 use craft\helpers\ElementHelper;
+use craft\helpers\StringHelper;
 use craft\services\Elements;
 use craft\utilities\ClearCaches;
 use craft\web\UrlManager;
@@ -33,10 +34,19 @@ use yii\caching\TagDependency;
  *    - `cdn:{environmentId}:{objectKey}` (object key has no leading slash)
  * - Added by Craft:
  *   - `{environmentShortId}{hashed}`
+ *   - `{environmentId}:overflow` (when the response has too many cache tags)
  */
 class StaticCache extends \yii\base\Component
 {
     public const CDN_PREFIX = 'cdn:';
+
+    /**
+     * Cloudflare's documented aggregate Cache-Tag value limit. It includes
+     * commas and whitespace, but excludes the header field name.
+     *
+     * @see https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
+     */
+    private const CLOUDFLARE_MAX_CACHE_TAG_HEADER_VALUE_LENGTH = 16 * 1024;
     private ?int $cacheDuration = null;
     private Collection $tags;
     private Collection $tagsToPurge;
@@ -224,12 +234,13 @@ class StaticCache extends \yii\base\Component
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->prepareTags(...$this->tags);
+        $cacheTags = $this->limitCacheTags($this->tags);
 
         Craft::info(new PsrMessage('Adding cache tags to response', [
-            'tags' => $this->tags,
+            'tags' => $cacheTags,
         ]), __METHOD__);
 
-        $this->tags
+        $cacheTags
             ->each(function(StaticCacheTag $tag) use ($headers) {
                 $headers->add(
                     HeaderEnum::CACHE_TAG->value,
@@ -256,6 +267,11 @@ class StaticCache extends \yii\base\Component
         if ($tags->isEmpty()) {
             return;
         }
+
+        $tags = $this->prepareTags(
+            StaticCacheTag::create($this->overflowTag()),
+            ...$tags,
+        );
 
         Craft::info(new PsrMessage('Purging tags', [
             'tags' => $tags,
@@ -370,5 +386,54 @@ class StaticCache extends \yii\base\Component
             ->map(fn(string|StaticCacheTag $tag) => is_string($tag) ? StaticCacheTag::create($tag) : $tag)
             ->filter(fn(StaticCacheTag $tag) => (bool) $tag->getValue())
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
+    }
+
+    private function limitCacheTags(Collection $tags): Collection
+    {
+        $cacheTags = $this->takeCacheTagsThatFit($tags);
+
+        if ($cacheTags->count() === $tags->count()) {
+            return $cacheTags;
+        }
+
+        $overflowTag = StaticCacheTag::create($this->overflowTag());
+        $cacheTags = $this->takeCacheTagsThatFit(
+            $this->prepareTags($overflowTag, ...$tags->values()->all()),
+        );
+        $exactTagCount = $cacheTags
+            ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
+            ->count();
+
+        Craft::warning(new PsrMessage('Cache tags exceed Cloudflare’s maximum header value length; using overflow tag', [
+            'emittedTags' => $cacheTags->count(),
+            'droppedTags' => $tags->count() - $exactTagCount,
+            'cloudflareMaxCacheTagHeaderValueLength' => self::CLOUDFLARE_MAX_CACHE_TAG_HEADER_VALUE_LENGTH,
+            'overflowTag' => $overflowTag->getValue(),
+        ]), __METHOD__);
+
+        return $cacheTags;
+    }
+
+    private function takeCacheTagsThatFit(Collection $tags): Collection
+    {
+        $headerValue = '';
+
+        return $tags->filter(function(StaticCacheTag $tag) use (&$headerValue) {
+            $value = $tag->getValue();
+            $newHeaderValue = $headerValue === '' ? $value : "$headerValue,$value";
+
+            if (StringHelper::byteLength($newHeaderValue) > self::CLOUDFLARE_MAX_CACHE_TAG_HEADER_VALUE_LENGTH) {
+                return false;
+            }
+
+            $headerValue = $newHeaderValue;
+
+            return true;
+        });
+    }
+
+    private function overflowTag(): string
+    {
+        return Module::getInstance()->getConfig()->environmentId . ':overflow';
     }
 }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -46,7 +46,7 @@ class StaticCache extends \yii\base\Component
      *
      * @see https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
      */
-    private const MAX_CACHE_TAG_HEADER_VALUE_LENGTH = 16 * 1024;
+    private const MAX_HEADER_VALUE_LENGTH = 16 * 1024;
     private ?int $cacheDuration = null;
     private Collection $tags;
     private Collection $tagsToPurge;
@@ -415,16 +415,16 @@ class StaticCache extends \yii\base\Component
         $cacheTags = $this->truncateCacheTags(
             $this->normalizeCacheTags($overflowTag, ...$tags->values()->all()),
         );
-        $totalTagCount = $tags
+        $sourceTags = $tags
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
-            ->count();
-        $exactTagCount = $cacheTags
+            ->values();
+        $emittedTags = $cacheTags
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
-            ->count();
+            ->values();
 
         Craft::warning(new PsrMessage('Cache tags exceed the maximum header value length; using overflow tag', [
-            'totalTags' => $totalTagCount,
-            'truncatedTags' => $totalTagCount - $exactTagCount,
+            'totalTags' => $sourceTags->count(),
+            'truncatedTags' => $sourceTags->count() - $emittedTags->count(),
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
 
@@ -439,7 +439,7 @@ class StaticCache extends \yii\base\Component
             $value = $tag->getValue();
             $newHeaderValue = $headerValue === '' ? $value : "$headerValue,$value";
 
-            if (StringHelper::byteLength($newHeaderValue) > self::MAX_CACHE_TAG_HEADER_VALUE_LENGTH) {
+            if (StringHelper::byteLength($newHeaderValue) > self::MAX_HEADER_VALUE_LENGTH) {
                 return false;
             }
 
@@ -451,6 +451,8 @@ class StaticCache extends \yii\base\Component
 
     private function overflowTag(): string
     {
-        return Module::getInstance()->getConfig()->environmentId . ':overflow';
+        $environmentId = Module::getInstance()->getConfig()->environmentId;
+
+        return "{$environmentId}:overflow";
     }
 }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -242,7 +242,7 @@ class StaticCache extends \yii\base\Component
             'tags' => $cacheTags,
         ]), __METHOD__);
 
-        $this->setCacheTagHeader(HeaderEnum::CACHE_TAG, $cacheTags);
+        $this->setCacheTagHeader(HeaderEnum::CACHE_TAG->value, $cacheTags);
     }
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
@@ -280,7 +280,7 @@ class StaticCache extends \yii\base\Component
             $tags = $this->prepareCacheTagsForHeader($tags);
 
             $this->setCacheTagHeader(
-                HeaderEnum::CACHE_PURGE_TAG,
+                HeaderEnum::CACHE_PURGE_TAG->value,
                 $tags,
             );
 
@@ -389,14 +389,14 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function setCacheTagHeader(HeaderEnum $header, Collection $tags): void
+    private function setCacheTagHeader(string $header, Collection $tags): void
     {
         if ($tags->isEmpty()) {
             return;
         }
 
         Craft::$app->getResponse()->getHeaders()->set(
-            $header->value,
+            $header,
             $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','),
         );
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -274,7 +274,7 @@ class StaticCache extends \yii\base\Component
         }
 
         $tags = $this->normalizeCacheTags(
-            StaticCacheTag::create($this->overflowTag()),
+            $this->overflowTag(),
             ...$tags,
         );
 
@@ -405,30 +405,38 @@ class StaticCache extends \yii\base\Component
 
     private function cacheTagsForHeader(Collection $tags): Collection
     {
-        $cacheTags = $this->truncateCacheTags($tags);
+        $headerTags = $this->truncateCacheTags($tags);
 
-        if ($cacheTags->count() === $tags->count()) {
-            return $cacheTags;
+        if ($headerTags->count() === $tags->count()) {
+            return $headerTags;
         }
 
-        $overflowTag = StaticCacheTag::create($this->overflowTag());
-        $cacheTags = $this->truncateCacheTags(
+        $overflowTag = $this->overflowTag();
+        $headerTags = $this->truncateCacheTags(
             $this->normalizeCacheTags($overflowTag, ...$tags->values()->all()),
         );
-        $sourceTags = $tags
+
+        $this->logTruncatedCacheTags($tags, $headerTags, $overflowTag);
+
+        return $headerTags;
+    }
+
+    private function logTruncatedCacheTags(Collection $tags, Collection $headerTags, StaticCacheTag $overflowTag): void
+    {
+        $totalTags = $tags
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
-            ->values();
-        $emittedTags = $cacheTags
+            ->count();
+        $headerTagCount = $headerTags
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
-            ->values();
+            ->count();
+        $truncatedTags = $totalTags - $headerTagCount;
 
         Craft::info(new PsrMessage('Cache tags exceed the maximum header value length; using overflow tag', [
-            'totalTags' => $sourceTags->count(),
-            'truncatedTags' => $sourceTags->count() - $emittedTags->count(),
+            'maxHeaderValueLength' => self::MAX_HEADER_VALUE_LENGTH,
+            'totalTags' => $totalTags,
+            'truncatedTags' => $truncatedTags,
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
-
-        return $cacheTags;
     }
 
     private function truncateCacheTags(Collection $tags): Collection
@@ -449,10 +457,10 @@ class StaticCache extends \yii\base\Component
         });
     }
 
-    private function overflowTag(): string
+    private function overflowTag(): StaticCacheTag
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
 
-        return "{$environmentId}:overflow";
+        return StaticCacheTag::create("{$environmentId}:overflow");
     }
 }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -260,12 +260,12 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        Craft::info(new PsrMessage('Purging tags', [
-            'tags' => $tags,
-        ]), __METHOD__);
-
         if ($isWebResponse) {
             $tags = $this->truncateCacheTagsForHeader($tags);
+
+            Craft::info(new PsrMessage('Purging tags', [
+                'tags' => $tags,
+            ]), __METHOD__);
 
             $this->setCacheTagHeader(
                 HeaderEnum::CACHE_PURGE_TAG->value,
@@ -274,6 +274,10 @@ class StaticCache extends \yii\base\Component
 
             return;
         }
+
+        Craft::info(new PsrMessage('Purging tags', [
+            'tags' => $tags,
+        ]), __METHOD__);
 
         Helper::createGatewayApiClient()->request('POST', 'cache/purge', [
             // Mapping to string because: https://github.com/laravel/framework/pull/54630

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -422,7 +422,7 @@ class StaticCache extends \yii\base\Component
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
             ->values();
 
-        Craft::warning(new PsrMessage('Cache tags exceed the maximum header value length; using overflow tag', [
+        Craft::info(new PsrMessage('Cache tags exceed the maximum header value length; using overflow tag', [
             'totalTags' => $sourceTags->count(),
             'truncatedTags' => $sourceTags->count() - $emittedTags->count(),
             'overflowTag' => $overflowTag->getValue(),

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -46,7 +46,7 @@ class StaticCache extends \yii\base\Component
      * @see https://developers.cloudflare.com/workers/cache/configuration/
      */
     private const MAX_HEADER_VALUE_LENGTH = 16 * 1024;
-    private const MAX_TAG_VALUE_LENGTH = 1024;
+    private const MAX_TAG_HEADER_VALUE_LENGTH = 1024;
     private const MAX_TAG_COUNT = 1000;
     private ?int $cacheDuration = null;
     private Collection $tags;
@@ -423,7 +423,7 @@ class StaticCache extends \yii\base\Component
         Craft::info(new PsrMessage('Cache tags exceed header limits; using overflow tag', [
             'maxHeaderValueLength' => self::MAX_HEADER_VALUE_LENGTH,
             'maxTagCount' => self::MAX_TAG_COUNT,
-            'maxTagValueLength' => self::MAX_TAG_VALUE_LENGTH,
+            'maxTagHeaderValueLength' => self::MAX_TAG_HEADER_VALUE_LENGTH,
             'truncatedTags' => $truncatedTagCount,
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
@@ -442,7 +442,7 @@ class StaticCache extends \yii\base\Component
 
             if (
                 $headerTags->count() === self::MAX_TAG_COUNT ||
-                StringHelper::byteLength($value) > self::MAX_TAG_VALUE_LENGTH
+                StringHelper::byteLength($value) > self::MAX_TAG_HEADER_VALUE_LENGTH
             ) {
                 break;
             }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -229,8 +229,7 @@ class StaticCache extends \yii\base\Component
             $this->staticCacheDirectives()->implode(','),
         );
 
-        // Capture and remove any existing headers, so we can prepare them
-        $existingTagsFromHeader = $this->parseCacheTagHeaders(
+        $existingTagsFromHeader = $this->parseCacheTagsFromHeaders(
             $headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? [],
         );
         $headers->remove(HeaderEnum::CACHE_TAG->value);
@@ -260,7 +259,7 @@ class StaticCache extends \yii\base\Component
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $existingTagsFromHeader = $this->parseCacheTagHeaders(
+            $existingTagsFromHeader = $this->parseCacheTagsFromHeaders(
                 $response->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value, first: false) ?? [],
             );
             $tags->push(...$existingTagsFromHeader);
@@ -395,7 +394,7 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function parseCacheTagHeaders(array $headers): Collection
+    private function parseCacheTagsFromHeaders(array $headers): Collection
     {
         return Collection::make($headers)
             ->flatMap(fn(string $header) => explode(',', $header))
@@ -416,13 +415,6 @@ class StaticCache extends \yii\base\Component
             $this->normalizeCacheTags($overflowTag, ...$tags->values()->all()),
         );
 
-        $this->logTruncatedCacheTags($tags, $headerTags, $overflowTag);
-
-        return $headerTags;
-    }
-
-    private function logTruncatedCacheTags(Collection $tags, Collection $headerTags, StaticCacheTag $overflowTag): void
-    {
         $inputTagCount = $tags
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
             ->count();
@@ -436,6 +428,8 @@ class StaticCache extends \yii\base\Component
             'truncatedTags' => $truncatedTagCount,
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
+
+        return $headerTags;
     }
 
     private function truncateCacheTags(Collection $tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -240,7 +240,11 @@ class StaticCache extends \yii\base\Component
             'tags' => $cacheTags,
         ]), __METHOD__);
 
-        $this->setCacheTagsHeader(HeaderEnum::CACHE_TAG, $headers, $cacheTags);
+        if ($cacheTags->isEmpty()) {
+            return;
+        }
+
+        $headers->set(HeaderEnum::CACHE_TAG->value, $this->cacheTagHeaderValue($cacheTags));
     }
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
@@ -265,7 +269,7 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        $tags = $this->addOverflowTag($tags, $this->overflowTag());
+        $tags = $this->normalizeCacheTags($this->overflowTag(), ...$tags);
 
         Craft::info(new PsrMessage('Purging tags', [
             'tags' => $tags,
@@ -274,7 +278,10 @@ class StaticCache extends \yii\base\Component
         if ($isWebResponse) {
             $tags = $this->prepareCacheTagsForHeader($tags);
 
-            $this->setCacheTagsHeader(HeaderEnum::CACHE_PURGE_TAG, $response->getHeaders(), $tags);
+            $response->getHeaders()->set(
+                HeaderEnum::CACHE_PURGE_TAG->value,
+                $this->cacheTagHeaderValue($tags),
+            );
 
             return;
         }
@@ -389,16 +396,9 @@ class StaticCache extends \yii\base\Component
             ->filter(fn(string $tag) => $tag !== '');
     }
 
-    private function setCacheTagsHeader(HeaderEnum $header, HeaderCollection $headers, Collection $tags): void
+    private function cacheTagHeaderValue(Collection $tags): string
     {
-        if ($tags->isEmpty()) {
-            return;
-        }
-
-        $headers->set(
-            $header->value,
-            $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','),
-        );
+        return $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(',');
     }
 
     private function prepareCacheTagsForHeader(Collection $tags): Collection
@@ -411,7 +411,7 @@ class StaticCache extends \yii\base\Component
 
         $overflowTag = $this->overflowTag();
         $headerTags = $this->truncateCacheTags(
-            $this->addOverflowTag($tags, $overflowTag),
+            $this->normalizeCacheTags($overflowTag, ...$tags),
         );
 
         $inputTagCount = $tags
@@ -429,14 +429,6 @@ class StaticCache extends \yii\base\Component
         ]), __METHOD__);
 
         return $headerTags;
-    }
-
-    private function addOverflowTag(Collection $tags, StaticCacheTag $overflowTag): Collection
-    {
-        return $this->normalizeCacheTags(
-            $overflowTag,
-            ...$tags->values()->all(),
-        );
     }
 
     private function truncateCacheTags(Collection $tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -423,18 +423,17 @@ class StaticCache extends \yii\base\Component
 
     private function logTruncatedCacheTags(Collection $tags, Collection $headerTags, StaticCacheTag $overflowTag): void
     {
-        $totalTags = $tags
+        $inputTagCount = $tags
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
             ->count();
         $headerTagCount = $headerTags
             ->reject(fn(StaticCacheTag $tag) => $tag->getValue() === $overflowTag->getValue())
             ->count();
-        $truncatedTags = $totalTags - $headerTagCount;
+        $truncatedTagCount = $inputTagCount - $headerTagCount;
 
         Craft::info(new PsrMessage('Cache tags exceed the maximum header value length; using overflow tag', [
             'maxHeaderValueLength' => self::MAX_HEADER_VALUE_LENGTH,
-            'totalTags' => $totalTags,
-            'truncatedTags' => $truncatedTags,
+            'truncatedTags' => $truncatedTagCount,
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -437,16 +437,17 @@ class StaticCache extends \yii\base\Component
         /** @var StaticCacheTag $tag */
         foreach ($tags as $tag) {
             $value = $tag->getValue();
+            $valueLength = StringHelper::byteLength($value);
 
             if (
                 $headerTags->count() === self::MAX_TAG_COUNT ||
-                StringHelper::byteLength($value) > self::MAX_TAG_VALUE_LENGTH
+                $valueLength > self::MAX_TAG_VALUE_LENGTH
             ) {
                 break;
             }
 
             $separatorLength = $headerValueLength === 0 ? 0 : 1;
-            $newHeaderValueLength = $headerValueLength + $separatorLength + StringHelper::byteLength($value);
+            $newHeaderValueLength = $headerValueLength + $separatorLength + $valueLength;
 
             if ($newHeaderValueLength > self::MAX_TAG_HEADER_VALUE_LENGTH) {
                 break;

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -41,12 +41,13 @@ class StaticCache extends \yii\base\Component
     public const CDN_PREFIX = 'cdn:';
 
     /**
-     * Cloudflare's documented aggregate Cache-Tag value limit. It includes
-     * commas and whitespace, but excludes the header field name.
+     * Cloudflare's documented Cache-Tag limits.
      *
-     * @see https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
+     * @see https://developers.cloudflare.com/workers/cache/configuration/
      */
     private const MAX_HEADER_VALUE_LENGTH = 16 * 1024;
+    private const MAX_TAG_VALUE_LENGTH = 1024;
+    private const MAX_TAG_COUNT = 1000;
     private ?int $cacheDuration = null;
     private Collection $tags;
     private Collection $tagsToPurge;
@@ -419,8 +420,10 @@ class StaticCache extends \yii\base\Component
             ->count();
         $truncatedTagCount = $inputTagCount - $headerTagCount;
 
-        Craft::info(new PsrMessage('Cache tags exceed the maximum header value length; using overflow tag', [
+        Craft::info(new PsrMessage('Cache tags exceed header limits; using overflow tag', [
             'maxHeaderValueLength' => self::MAX_HEADER_VALUE_LENGTH,
+            'maxTagCount' => self::MAX_TAG_COUNT,
+            'maxTagValueLength' => self::MAX_TAG_VALUE_LENGTH,
             'truncatedTags' => $truncatedTagCount,
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
@@ -436,6 +439,14 @@ class StaticCache extends \yii\base\Component
         /** @var StaticCacheTag $tag */
         foreach ($tags as $tag) {
             $value = $tag->getValue();
+
+            if (
+                $headerTags->count() === self::MAX_TAG_COUNT ||
+                StringHelper::byteLength($value) > self::MAX_TAG_VALUE_LENGTH
+            ) {
+                break;
+            }
+
             $separatorLength = $headerValueLength === 0 ? 0 : 1;
             $newHeaderValueLength = $headerValueLength + $separatorLength + StringHelper::byteLength($value);
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -21,7 +21,6 @@ use League\Uri\Components\Path;
 use samdark\log\PsrMessage;
 use yii\base\Event;
 use yii\caching\TagDependency;
-use yii\web\HeaderCollection;
 
 /**
  * Static Cache tags can appear in the `Cache-Tag` and `Cache-Purge-Tag` headers.
@@ -243,7 +242,7 @@ class StaticCache extends \yii\base\Component
             'tags' => $cacheTags,
         ]), __METHOD__);
 
-        $this->setCacheTagHeader(HeaderEnum::CACHE_TAG->value, $headers, $cacheTags);
+        $this->setCacheTagHeader(HeaderEnum::CACHE_TAG, $cacheTags);
     }
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
@@ -281,8 +280,7 @@ class StaticCache extends \yii\base\Component
             $tags = $this->prepareCacheTagsForHeader($tags);
 
             $this->setCacheTagHeader(
-                HeaderEnum::CACHE_PURGE_TAG->value,
-                $response->getHeaders(),
+                HeaderEnum::CACHE_PURGE_TAG,
                 $tags,
             );
 
@@ -391,13 +389,16 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function setCacheTagHeader(string $header, HeaderCollection $headers, Collection $tags): void
+    private function setCacheTagHeader(HeaderEnum $header, Collection $tags): void
     {
         if ($tags->isEmpty()) {
             return;
         }
 
-        $headers->set($header, $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','));
+        Craft::$app->getResponse()->getHeaders()->set(
+            $header->value,
+            $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','),
+        );
     }
 
     private function prepareCacheTagsForHeader(Collection $tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -45,8 +45,8 @@ class StaticCache extends \yii\base\Component
      *
      * @see https://developers.cloudflare.com/workers/cache/configuration/
      */
-    private const MAX_HEADER_VALUE_LENGTH = 16 * 1024;
-    private const MAX_TAG_HEADER_VALUE_LENGTH = 1024;
+    private const MAX_TAG_HEADER_VALUE_LENGTH = 16 * 1024;
+    private const MAX_TAG_VALUE_LENGTH = 1024;
     private const MAX_TAG_COUNT = 1000;
     private ?int $cacheDuration = null;
     private Collection $tags;
@@ -421,9 +421,9 @@ class StaticCache extends \yii\base\Component
         $truncatedTagCount = $inputTagCount - $headerTagCount;
 
         Craft::info(new PsrMessage('Cache tags exceed header limits; using overflow tag', [
-            'maxHeaderValueLength' => self::MAX_HEADER_VALUE_LENGTH,
-            'maxTagCount' => self::MAX_TAG_COUNT,
             'maxTagHeaderValueLength' => self::MAX_TAG_HEADER_VALUE_LENGTH,
+            'maxTagCount' => self::MAX_TAG_COUNT,
+            'maxTagValueLength' => self::MAX_TAG_VALUE_LENGTH,
             'truncatedTags' => $truncatedTagCount,
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
@@ -442,7 +442,7 @@ class StaticCache extends \yii\base\Component
 
             if (
                 $headerTags->count() === self::MAX_TAG_COUNT ||
-                StringHelper::byteLength($value) > self::MAX_TAG_HEADER_VALUE_LENGTH
+                StringHelper::byteLength($value) > self::MAX_TAG_VALUE_LENGTH
             ) {
                 break;
             }
@@ -450,7 +450,7 @@ class StaticCache extends \yii\base\Component
             $separatorLength = $headerValueLength === 0 ? 0 : 1;
             $newHeaderValueLength = $headerValueLength + $separatorLength + StringHelper::byteLength($value);
 
-            if ($newHeaderValueLength > self::MAX_HEADER_VALUE_LENGTH) {
+            if ($newHeaderValueLength > self::MAX_TAG_HEADER_VALUE_LENGTH) {
                 break;
             }
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -229,7 +229,7 @@ class StaticCache extends \yii\base\Component
             $this->staticCacheDirectives()->implode(','),
         );
 
-        $existingTagsFromHeader = $this->parseCacheTagsFromHeaders(
+        $existingTagsFromHeader = $this->parseCacheTagsFromHeader(
             $headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? [],
         );
         $headers->remove(HeaderEnum::CACHE_TAG->value);
@@ -259,7 +259,7 @@ class StaticCache extends \yii\base\Component
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $existingTagsFromHeader = $this->parseCacheTagsFromHeaders(
+            $existingTagsFromHeader = $this->parseCacheTagsFromHeader(
                 $response->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value, first: false) ?? [],
             );
             $tags->push(...$existingTagsFromHeader);
@@ -394,7 +394,7 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function parseCacheTagsFromHeaders(array $headers): Collection
+    private function parseCacheTagsFromHeader(array $headers): Collection
     {
         return Collection::make($headers)
             ->flatMap(fn(string $header) => explode(',', $header))

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -230,7 +230,10 @@ class StaticCache extends \yii\base\Component
             $this->staticCacheDirectives()->implode(','),
         );
 
-        $existingTagsFromHeader = $this->parseCacheTagsFromHeaders(HeaderEnum::CACHE_TAG->value, $headers);
+        $existingTagsFromHeader = Collection::make($headers->get(HeaderEnum::CACHE_TAG->value, first: false) ?? [])
+            ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
+            ->map(fn(string $tag) => trim($tag))
+            ->filter(fn(string $tag) => $tag !== '');
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->normalizeCacheTags(...$this->tags);
@@ -240,11 +243,7 @@ class StaticCache extends \yii\base\Component
             'tags' => $cacheTags,
         ]), __METHOD__);
 
-        if ($cacheTags->isEmpty()) {
-            return;
-        }
-
-        $headers->set(HeaderEnum::CACHE_TAG->value, $this->cacheTagHeaderValue($cacheTags));
+        $this->setCacheTagHeader(HeaderEnum::CACHE_TAG->value, $headers, $cacheTags);
     }
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
@@ -255,10 +254,13 @@ class StaticCache extends \yii\base\Component
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $existingTagsFromHeader = $this->parseCacheTagsFromHeaders(
+            $existingTagsFromHeader = Collection::make($response->getHeaders()->get(
                 HeaderEnum::CACHE_PURGE_TAG->value,
-                $response->getHeaders(),
-            );
+                first: false,
+            ) ?? [])
+                ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
+                ->map(fn(string $tag) => trim($tag))
+                ->filter(fn(string $tag) => $tag !== '');
             $tags->push(...$existingTagsFromHeader);
             $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
         }
@@ -278,9 +280,10 @@ class StaticCache extends \yii\base\Component
         if ($isWebResponse) {
             $tags = $this->prepareCacheTagsForHeader($tags);
 
-            $response->getHeaders()->set(
+            $this->setCacheTagHeader(
                 HeaderEnum::CACHE_PURGE_TAG->value,
-                $this->cacheTagHeaderValue($tags),
+                $response->getHeaders(),
+                $tags,
             );
 
             return;
@@ -388,17 +391,13 @@ class StaticCache extends \yii\base\Component
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
-    private function parseCacheTagsFromHeaders(string $header, HeaderCollection $headers): Collection
+    private function setCacheTagHeader(string $header, HeaderCollection $headers, Collection $tags): void
     {
-        return Collection::make($headers->get($header, first: false) ?? [])
-            ->flatMap(fn(string $headerValue) => explode(',', $headerValue))
-            ->map(fn(string $tag) => trim($tag))
-            ->filter(fn(string $tag) => $tag !== '');
-    }
+        if ($tags->isEmpty()) {
+            return;
+        }
 
-    private function cacheTagHeaderValue(Collection $tags): string
-    {
-        return $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(',');
+        $headers->set($header, $tags->map(fn(StaticCacheTag $tag) => $tag->getValue())->implode(','));
     }
 
     private function prepareCacheTagsForHeader(Collection $tags): Collection

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -236,7 +236,7 @@ class StaticCache extends \yii\base\Component
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->normalizeCacheTags(...$this->tags);
-        $cacheTags = $this->withOverflowTagIfNeeded($this->tags);
+        $cacheTags = $this->cacheTagsForHeader($this->tags);
 
         Craft::info(new PsrMessage('Adding cache tags to response', [
             'tags' => $cacheTags,
@@ -283,7 +283,7 @@ class StaticCache extends \yii\base\Component
         ]), __METHOD__);
 
         if ($isWebResponse) {
-            $tags = $this->withOverflowTagIfNeeded($tags);
+            $tags = $this->cacheTagsForHeader($tags);
 
             $response->getHeaders()->set(
                 HeaderEnum::CACHE_PURGE_TAG->value,
@@ -391,17 +391,19 @@ class StaticCache extends \yii\base\Component
     {
         return Collection::make($tags)
             ->map(fn(string|StaticCacheTag $tag) => is_string($tag) ? StaticCacheTag::create($tag) : $tag)
-            ->filter(fn(StaticCacheTag $tag) => (bool) $tag->getValue())
+            ->filter(fn(StaticCacheTag $tag) => $tag->getValue() !== '')
             ->unique(fn(StaticCacheTag $tag) => $tag->getValue());
     }
 
     private function splitCacheTagHeaders(array $headers): Collection
     {
         return Collection::make($headers)
-            ->flatMap(fn(string $header) => explode(',', $header));
+            ->flatMap(fn(string $header) => explode(',', $header))
+            ->map(fn(string $tag) => trim($tag))
+            ->filter(fn(string $tag) => $tag !== '');
     }
 
-    private function withOverflowTagIfNeeded(Collection $tags): Collection
+    private function cacheTagsForHeader(Collection $tags): Collection
     {
         $cacheTags = $this->truncateCacheTags($tags);
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -229,9 +229,8 @@ class StaticCache extends \yii\base\Component
             $this->staticCacheDirectives()->implode(','),
         );
 
-        $existingTagsFromHeader = $this->parseCacheTagsFromHeader(HeaderEnum::CACHE_TAG->value);
+        $this->tags->push(...$this->parseCacheTagsFromHeader(HeaderEnum::CACHE_TAG->value));
         $headers->remove(HeaderEnum::CACHE_TAG->value);
-        $this->tags->push(...$existingTagsFromHeader);
         $this->tags = $this->normalizeCacheTags(...$this->tags);
         $cacheTags = $this->prepareCacheTagsForHeader($this->tags);
 
@@ -250,8 +249,7 @@ class StaticCache extends \yii\base\Component
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $existingTagsFromHeader = $this->parseCacheTagsFromHeader(HeaderEnum::CACHE_PURGE_TAG->value);
-            $tags->push(...$existingTagsFromHeader);
+            $tags->push(...$this->parseCacheTagsFromHeader(HeaderEnum::CACHE_PURGE_TAG->value));
             $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
         }
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -232,7 +232,7 @@ class StaticCache extends \yii\base\Component
         $this->tags->push(...$this->parseCacheTagsFromHeader(HeaderEnum::CACHE_TAG->value));
         $headers->remove(HeaderEnum::CACHE_TAG->value);
         $this->tags = $this->normalizeCacheTags(...$this->tags);
-        $cacheTags = $this->prepareCacheTagsForHeader($this->tags);
+        $cacheTags = $this->truncateCacheTagsForHeader($this->tags);
 
         Craft::info(new PsrMessage('Adding cache tags to response', [
             'tags' => $cacheTags,
@@ -266,7 +266,7 @@ class StaticCache extends \yii\base\Component
         ]), __METHOD__);
 
         if ($isWebResponse) {
-            $tags = $this->prepareCacheTagsForHeader($tags);
+            $tags = $this->truncateCacheTagsForHeader($tags);
 
             $this->setCacheTagHeader(
                 HeaderEnum::CACHE_PURGE_TAG->value,
@@ -398,7 +398,7 @@ class StaticCache extends \yii\base\Component
         );
     }
 
-    private function prepareCacheTagsForHeader(Collection $tags): Collection
+    private function truncateCacheTagsForHeader(Collection $tags): Collection
     {
         $headerTags = $this->truncateCacheTags($tags);
 
@@ -431,20 +431,23 @@ class StaticCache extends \yii\base\Component
     private function truncateCacheTags(Collection $tags): Collection
     {
         $headerValueLength = 0;
+        $headerTags = Collection::make();
 
-        return $tags->filter(function(StaticCacheTag $tag) use (&$headerValueLength) {
+        /** @var StaticCacheTag $tag */
+        foreach ($tags as $tag) {
             $value = $tag->getValue();
             $separatorLength = $headerValueLength === 0 ? 0 : 1;
             $newHeaderValueLength = $headerValueLength + $separatorLength + StringHelper::byteLength($value);
 
             if ($newHeaderValueLength > self::MAX_HEADER_VALUE_LENGTH) {
-                return false;
+                break;
             }
 
             $headerValueLength = $newHeaderValueLength;
+            $headerTags->push($tag);
+        }
 
-            return true;
-        });
+        return $headerTags;
     }
 
     private function overflowTag(): StaticCacheTag

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -426,7 +426,7 @@ class StaticCache extends \yii\base\Component
             'maxTagHeaderValueLength' => self::MAX_TAG_HEADER_VALUE_LENGTH,
             'maxTagCount' => self::MAX_TAG_COUNT,
             'maxTagValueLength' => self::MAX_TAG_VALUE_LENGTH,
-            'truncatedTags' => $truncatedTagCount,
+            'truncatedTagCount' => $truncatedTagCount,
             'overflowTag' => $overflowTag->getValue(),
         ]), __METHOD__);
 

--- a/src/StaticCacheTag.php
+++ b/src/StaticCacheTag.php
@@ -46,7 +46,7 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
                 ->value;
         }
 
-        return $this->normalize()->value;
+        return $this->normalizedValue();
     }
 
     public function withPrefix(string $prefix): self
@@ -63,17 +63,15 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
         return $this;
     }
 
-    private function normalize(): self
+    private function normalizedValue(): string
     {
         // Cache tags need printable ASCII with no spaces or commas.
         // @see https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
-        $this->value = preg_replace_callback(
+        return preg_replace_callback(
             self::INVALID_CHARS,
             fn(array $match) => rawurlencode($match[0]),
             $this->value,
         ) ?? $this->value;
-
-        return $this;
     }
 
     private function hash(): self

--- a/src/StaticCacheTag.php
+++ b/src/StaticCacheTag.php
@@ -33,17 +33,18 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
 
     public function getValue(): string
     {
-        $clone = clone $this;
-        $clone->removeInvalidCharacters();
+        if (!$this->value) {
+            return '';
+        }
 
-        if ($clone->value && $clone->minify) {
-            return self::create($clone->value)
+        if ($this->minify) {
+            return self::create($this->value)
                 ->hash()
                 ->withPrefix(Module::getInstance()->getConfig()->getShortEnvironmentId())
                 ->value;
         }
 
-        return $clone->value;
+        return $this->isValidCacheTag() ? $this->value : '';
     }
 
     public function withPrefix(string $prefix): self
@@ -60,14 +61,11 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
         return $this;
     }
 
-    private function removeInvalidCharacters(): self
+    private function isValidCacheTag(): bool
     {
-        // Filter non-ASCII characters and asterisks, as these will tags end up in headers.
-        // Asterisks should be valid, but Lambda mysteriously dies
-        // with a 502 if they're present in the value of a response header.
-        $this->value = preg_replace('/[^\x00-\x7F]|\*/', '', $this->value);
-
-        return $this;
+        // Cloudflare accepts printable ASCII, except spaces. A comma separates tags.
+        // @see https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
+        return preg_match('/^[\x21-\x2B\x2D-\x7E]+$/', $this->value) === 1;
     }
 
     private function hash(): self

--- a/src/StaticCacheTag.php
+++ b/src/StaticCacheTag.php
@@ -4,7 +4,7 @@ namespace craft\cloud;
 
 class StaticCacheTag implements \Stringable, \JsonSerializable
 {
-    private const INVALID_CACHE_TAG_CHARACTERS = '/[^\x21-\x2B\x2D-\x7E]/';
+    private const INVALID_CHARS = '/[^\x21-\x2B\x2D-\x7E]/';
 
     public readonly string $originalValue;
     private bool $minify = false;
@@ -35,7 +35,7 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
 
     public function getValue(): string
     {
-        if (!$this->value) {
+        if ($this->value === '') {
             return '';
         }
 
@@ -68,7 +68,7 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
         // Cache tags need printable ASCII with no spaces or commas.
         // @see https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
         $this->value = preg_replace_callback(
-            self::INVALID_CACHE_TAG_CHARACTERS,
+            self::INVALID_CHARS,
             fn(array $match) => rawurlencode($match[0]),
             $this->value,
         ) ?? $this->value;

--- a/src/StaticCacheTag.php
+++ b/src/StaticCacheTag.php
@@ -42,7 +42,7 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
         if ($this->minify) {
             return self::create($this->value)
                 ->hash()
-                ->withPrefix(Module::getInstance()->getConfig()->getShortEnvironmentId())
+                ->withPrefix(Module::getInstance()->getConfig()->getShortEnvironmentId() ?? '')
                 ->value;
         }
 

--- a/src/StaticCacheTag.php
+++ b/src/StaticCacheTag.php
@@ -4,6 +4,8 @@ namespace craft\cloud;
 
 class StaticCacheTag implements \Stringable, \JsonSerializable
 {
+    private const INVALID_CACHE_TAG_CHARACTERS = '/[^\x21-\x2B\x2D-\x7E]/';
+
     public readonly string $originalValue;
     private bool $minify = false;
 
@@ -44,7 +46,7 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
                 ->value;
         }
 
-        return $this->isValidCacheTag() ? $this->value : '';
+        return $this->normalize()->value;
     }
 
     public function withPrefix(string $prefix): self
@@ -61,11 +63,17 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
         return $this;
     }
 
-    private function isValidCacheTag(): bool
+    private function normalize(): self
     {
-        // Cloudflare accepts printable ASCII, except spaces. A comma separates tags.
+        // Cache tags need printable ASCII with no spaces or commas.
         // @see https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-tags/#a-few-things-to-remember
-        return preg_match('/^[\x21-\x2B\x2D-\x7E]+$/', $this->value) === 1;
+        $this->value = preg_replace_callback(
+            self::INVALID_CACHE_TAG_CHARACTERS,
+            fn(array $match) => rawurlencode($match[0]),
+            $this->value,
+        ) ?? $this->value;
+
+        return $this;
     }
 
     private function hash(): self

--- a/src/web/ResponseEventHandler.php
+++ b/src/web/ResponseEventHandler.php
@@ -6,7 +6,6 @@ use Craft;
 use craft\cloud\fs\TmpFs;
 use craft\cloud\HeaderEnum;
 use craft\cloud\Module;
-use craft\helpers\StringHelper;
 use craft\web\Response;
 use Illuminate\Support\Collection;
 use yii\base\Event;
@@ -16,13 +15,6 @@ use yii\web\ServerErrorHttpException;
 class ResponseEventHandler
 {
     private Response $response;
-
-    /**
-     * @see https://developers.cloudflare.com/workers/platform/limits/#request-limits
-     * @see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html#http-headers-quotas
-     * @see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html
-     */
-    private const MAX_HEADER_LENGTH = 16 * 1024;
 
     public function __construct()
     {
@@ -43,8 +35,6 @@ class ResponseEventHandler
         if (Module::getInstance()->getConfig()->getDevMode()) {
             $this->addDevModeHeader();
         }
-
-        $this->normalizeHeaders();
 
         if (Module::getInstance()->getConfig()->gzipResponse) {
             $this->gzipResponse();
@@ -116,41 +106,6 @@ class ResponseEventHandler
         // Ensure we don't recursively call send()
         // @see https://github.com/craftcms/cms/pull/15014
         Craft::$app->end();
-    }
-
-    private function normalizeHeaders(): void
-    {
-        Collection::make($this->response->getHeaders())
-            ->each(function(array $values, string $name) {
-                if (HeaderEnum::SET_COOKIE->matches($name)) {
-                    return;
-                }
-
-                $this->response->getHeaders()->set(
-                    $name,
-                    $this->joinHeaderValues($values),
-                );
-            });
-    }
-
-    private function joinHeaderValues(array $values): string
-    {
-        return Collection::make($values)
-            ->filter()
-            ->reduce(function($result, $value) {
-                $newResult = $result === '' ? $value : $result . ',' . $value;
-
-                if (StringHelper::byteLength($newResult) > self::MAX_HEADER_LENGTH) {
-                    Craft::warning(
-                        sprintf("Header value exceeds the maximum length of %s bytes; truncating response.", self::MAX_HEADER_LENGTH),
-                        __METHOD__,
-                    );
-
-                    return $result;
-                }
-
-                return $newResult;
-            }, '');
     }
 
     private function addDevModeHeader(): void

--- a/tests/unit/StaticCacheTagTest.php
+++ b/tests/unit/StaticCacheTagTest.php
@@ -41,11 +41,14 @@ class StaticCacheTagTest extends Unit
         $this->assertSame('tag%C3%A9value', StaticCacheTag::create('tagévalue')->getValue());
     }
 
-    public function testMinifiesOriginalValueBeforeValidation(): void
+    public function testMinifiesOriginalValueAfterGettingNormalizedValue(): void
     {
+        $tag = StaticCacheTag::create('tag value');
+
+        $this->assertSame('tag%20value', $tag->getValue());
         $this->assertSame(
-            Module::getInstance()->getConfig()->getShortEnvironmentId() . sprintf('%x', crc32('tag*value')),
-            StaticCacheTag::create('tag*value')->minify(true)->getValue(),
+            Module::getInstance()->getConfig()->getShortEnvironmentId() . sprintf('%x', crc32('tag value')),
+            $tag->minify(true)->getValue(),
         );
     }
 }

--- a/tests/unit/StaticCacheTagTest.php
+++ b/tests/unit/StaticCacheTagTest.php
@@ -16,6 +16,7 @@ class StaticCacheTagTest extends Unit
 
         $this->previousModule = Module::getInstance();
         Module::setInstance(new Module('cloud'));
+        Module::getInstance()->getConfig()->environmentId = '123-environment-id';
     }
 
     protected function _after(): void

--- a/tests/unit/StaticCacheTagTest.php
+++ b/tests/unit/StaticCacheTagTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace craft\cloud\tests\unit;
+
+use Codeception\Test\Unit;
+use craft\cloud\Module;
+use craft\cloud\StaticCacheTag;
+
+class StaticCacheTagTest extends Unit
+{
+    public function testPreservesValidTags(): void
+    {
+        $this->assertSame('tag*value', StaticCacheTag::create('tag*value')->getValue());
+        $this->assertSame('tag:value', StaticCacheTag::create('tag:value')->getValue());
+    }
+
+    public function testDropsInvalidTags(): void
+    {
+        foreach (["tag value", 'tag,value', "tag\tvalue", 'tagévalue'] as $value) {
+            $this->assertSame('', StaticCacheTag::create($value)->getValue());
+        }
+    }
+
+    public function testMinifiesOriginalValueBeforeValidation(): void
+    {
+        $this->assertSame(
+            Module::getInstance()->getConfig()->getShortEnvironmentId() . sprintf('%x', crc32('tag*value')),
+            StaticCacheTag::create('tag*value')->minify(true)->getValue(),
+        );
+    }
+}

--- a/tests/unit/StaticCacheTagTest.php
+++ b/tests/unit/StaticCacheTagTest.php
@@ -30,6 +30,7 @@ class StaticCacheTagTest extends Unit
     {
         $this->assertSame('tag*value', StaticCacheTag::create('tag*value')->getValue());
         $this->assertSame('tag:value', StaticCacheTag::create('tag:value')->getValue());
+        $this->assertSame('0', StaticCacheTag::create('0')->getValue());
     }
 
     public function testNormalizesInvalidTags(): void

--- a/tests/unit/StaticCacheTagTest.php
+++ b/tests/unit/StaticCacheTagTest.php
@@ -8,17 +8,35 @@ use craft\cloud\StaticCacheTag;
 
 class StaticCacheTagTest extends Unit
 {
+    private ?Module $previousModule = null;
+
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->previousModule = Module::getInstance();
+        Module::setInstance(new Module('cloud'));
+    }
+
+    protected function _after(): void
+    {
+        Module::setInstance($this->previousModule);
+
+        parent::_after();
+    }
+
     public function testPreservesValidTags(): void
     {
         $this->assertSame('tag*value', StaticCacheTag::create('tag*value')->getValue());
         $this->assertSame('tag:value', StaticCacheTag::create('tag:value')->getValue());
     }
 
-    public function testDropsInvalidTags(): void
+    public function testNormalizesInvalidTags(): void
     {
-        foreach (["tag value", 'tag,value', "tag\tvalue", 'tagévalue'] as $value) {
-            $this->assertSame('', StaticCacheTag::create($value)->getValue());
-        }
+        $this->assertSame('tag%20value', StaticCacheTag::create('tag value')->getValue());
+        $this->assertSame('tag%2Cvalue', StaticCacheTag::create('tag,value')->getValue());
+        $this->assertSame('tag%09value', StaticCacheTag::create("tag\tvalue")->getValue());
+        $this->assertSame('tag%C3%A9value', StaticCacheTag::create('tagévalue')->getValue());
     }
 
     public function testMinifiesOriginalValueBeforeValidation(): void

--- a/tests/unit/StaticCacheTagTest.php
+++ b/tests/unit/StaticCacheTagTest.php
@@ -51,4 +51,14 @@ class StaticCacheTagTest extends Unit
             $tag->minify(true)->getValue(),
         );
     }
+
+    public function testMinifiesValueWithoutEnvironmentId(): void
+    {
+        Module::getInstance()->getConfig()->environmentId = null;
+
+        $this->assertSame(
+            sprintf('%x', crc32('tag value')),
+            StaticCacheTag::create('tag value')->minify(true)->getValue(),
+        );
+    }
 }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -22,10 +22,14 @@ class StaticCacheTest extends Unit
 
     private ?string $requestMethod = null;
     private ?string $environmentId = null;
+    private ?Module $previousModule = null;
 
     protected function _before(): void
     {
         parent::_before();
+
+        $this->previousModule = Module::getInstance();
+        Module::setInstance(new Module('cloud'));
 
         Craft::$app->getRequest()->setIsCpRequest(false);
         Craft::$app->getResponse()->clear();
@@ -43,6 +47,7 @@ class StaticCacheTest extends Unit
         Craft::$app->getRequest()->setIsCpRequest(null);
         Craft::$app->getResponse()->clear();
         Module::getInstance()->getConfig()->environmentId = $this->environmentId;
+        Module::setInstance($this->previousModule);
 
         if ($this->requestMethod === null) {
             unset($_SERVER['REQUEST_METHOD']);
@@ -110,10 +115,11 @@ class StaticCacheTest extends Unit
 
         $this->addCacheHeadersToWebResponse($staticCache);
 
-        $tags = Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value, first: false);
+        $cacheTagHeader = Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value);
+        $tags = explode(',', $cacheTagHeader);
 
         $this->assertSame('123-environment-id:overflow', $tags[0]);
-        $this->assertLessThanOrEqual(16 * 1024, StringHelper::byteLength(implode(',', $tags)));
+        $this->assertLessThanOrEqual(16 * 1024, StringHelper::byteLength($cacheTagHeader));
         $this->assertContains('tag-1-' . str_repeat('x', 24), $tags);
         $this->assertNotContains('tag-1000-' . str_repeat('x', 24), $tags);
     }
@@ -121,13 +127,43 @@ class StaticCacheTest extends Unit
     public function testPurgeTagsIncludeOverflowFallbackTag(): void
     {
         $staticCache = new StaticCache();
+        Craft::$app->getResponse()->getHeaders()->set(HeaderEnum::CACHE_PURGE_TAG->value, 'first,second');
 
-        $staticCache->purgeTags('first', 'second');
+        $staticCache->purgeTags();
 
         $this->assertSame(
-            ['123-environment-id:overflow', 'first', 'second'],
-            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value, first: false),
+            '123-environment-id:overflow,first,second',
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
+    }
+
+    public function testExistingCacheTagHeaderIsSplit(): void
+    {
+        $staticCache = new StaticCache();
+        $staticCache->init();
+        Craft::$app->getResponse()->getHeaders()->set(HeaderEnum::CACHE_TAG->value, 'first,second');
+
+        $this->addCacheHeadersToWebResponse($staticCache);
+
+        $this->assertSame(
+            'first,second',
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value),
+        );
+    }
+
+    public function testPurgeTagHeaderUsesOverflowFallbackWhenItIsTooLong(): void
+    {
+        $staticCache = new StaticCache();
+        $tags = Collection::range(1, 1000)
+            ->map(fn(int $index) => "tag-$index-" . str_repeat('x', 24))
+            ->all();
+
+        $staticCache->purgeTags(...$tags);
+
+        $cachePurgeTagHeader = Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value);
+
+        $this->assertStringStartsWith('123-environment-id:overflow,', $cachePurgeTagHeader);
+        $this->assertLessThanOrEqual(16 * 1024, StringHelper::byteLength($cachePurgeTagHeader));
     }
 
     private function isCacheable(StaticCache $staticCache): bool

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -124,12 +124,12 @@ class StaticCacheTest extends Unit
         $this->assertNotContains('tag-1000-' . str_repeat('x', 24), $tags);
     }
 
-    public function testCacheTagOverflowTruncatesRemainingTags(): void
+    public function testCacheTagOverflowTruncatesTagsThatExceedTheMaximumLength(): void
     {
         $staticCache = new StaticCache();
         $staticCache->init();
         $this->setTags($staticCache, Collection::make([
-            StaticCacheTag::create(str_repeat('x', 16 * 1024)),
+            StaticCacheTag::create(str_repeat('x', 1025)),
             StaticCacheTag::create('second'),
         ]));
 
@@ -139,6 +139,40 @@ class StaticCacheTest extends Unit
             '123-environment-id:overflow',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value),
         );
+    }
+
+    public function testCacheTagAtMaximumLengthIsAddedToTheHeader(): void
+    {
+        $staticCache = new StaticCache();
+        $staticCache->init();
+        $tag = str_repeat('x', 1024);
+        $this->setTags($staticCache, Collection::make([
+            StaticCacheTag::create($tag),
+        ]));
+
+        $this->addCacheHeadersToWebResponse($staticCache);
+
+        $this->assertSame(
+            $tag,
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value),
+        );
+    }
+
+    public function testCacheTagOverflowTruncatesTagsThatExceedTheMaximumCount(): void
+    {
+        $staticCache = new StaticCache();
+        $staticCache->init();
+        $this->setTags($staticCache, Collection::range(1, 1001)
+            ->map(fn(int $index) => StaticCacheTag::create("tag-$index")));
+
+        $this->addCacheHeadersToWebResponse($staticCache);
+
+        $tags = explode(',', Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value));
+
+        $this->assertSame('123-environment-id:overflow', $tags[0]);
+        $this->assertCount(1000, $tags);
+        $this->assertContains('tag-999', $tags);
+        $this->assertNotContains('tag-1000', $tags);
     }
 
     public function testPurgeTagsIncludeOverflowFallbackTag(): void

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -5,9 +5,13 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\HeaderEnum;
+use craft\cloud\Module;
 use craft\cloud\StaticCache;
+use craft\cloud\StaticCacheTag;
+use craft\helpers\StringHelper;
 use Illuminate\Support\Collection;
 use ReflectionMethod;
+use ReflectionProperty;
 
 class StaticCacheTest extends Unit
 {
@@ -17,6 +21,7 @@ class StaticCacheTest extends Unit
     protected $tester;
 
     private ?string $requestMethod = null;
+    private ?string $environmentId = null;
 
     protected function _before(): void
     {
@@ -26,6 +31,9 @@ class StaticCacheTest extends Unit
         Craft::$app->getResponse()->clear();
         Craft::$app->getResponse()->setStatusCode(200);
 
+        $this->environmentId = Module::getInstance()->getConfig()->environmentId;
+        Module::getInstance()->getConfig()->environmentId = '123-environment-id';
+
         $this->requestMethod = $_SERVER['REQUEST_METHOD'] ?? null;
         $_SERVER['REQUEST_METHOD'] = 'GET';
     }
@@ -34,6 +42,7 @@ class StaticCacheTest extends Unit
     {
         Craft::$app->getRequest()->setIsCpRequest(null);
         Craft::$app->getResponse()->clear();
+        Module::getInstance()->getConfig()->environmentId = $this->environmentId;
 
         if ($this->requestMethod === null) {
             unset($_SERVER['REQUEST_METHOD']);
@@ -92,6 +101,35 @@ class StaticCacheTest extends Unit
         );
     }
 
+    public function testCacheTagOverflowUsesFallbackTag(): void
+    {
+        $staticCache = new StaticCache();
+        $staticCache->init();
+        $this->setTags($staticCache, Collection::range(1, 1000)
+            ->map(fn(int $index) => StaticCacheTag::create("tag-$index-" . str_repeat('x', 24))));
+
+        $this->addCacheHeadersToWebResponse($staticCache);
+
+        $tags = Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value, first: false);
+
+        $this->assertSame('123-environment-id:overflow', $tags[0]);
+        $this->assertLessThanOrEqual(16 * 1024, StringHelper::byteLength(implode(',', $tags)));
+        $this->assertContains('tag-1-' . str_repeat('x', 24), $tags);
+        $this->assertNotContains('tag-1000-' . str_repeat('x', 24), $tags);
+    }
+
+    public function testPurgeTagsIncludeOverflowFallbackTag(): void
+    {
+        $staticCache = new StaticCache();
+
+        $staticCache->purgeTags('first', 'second');
+
+        $this->assertSame(
+            ['123-environment-id:overflow', 'first', 'second'],
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value, first: false),
+        );
+    }
+
     private function isCacheable(StaticCache $staticCache): bool
     {
         $method = new ReflectionMethod($staticCache, 'isCacheable');
@@ -106,5 +144,19 @@ class StaticCacheTest extends Unit
         $method->setAccessible(true);
 
         return $method->invoke($staticCache);
+    }
+
+    private function addCacheHeadersToWebResponse(StaticCache $staticCache): void
+    {
+        $method = new ReflectionMethod($staticCache, 'addCacheHeadersToWebResponse');
+        $method->setAccessible(true);
+        $method->invoke($staticCache);
+    }
+
+    private function setTags(StaticCache $staticCache, Collection $tags): void
+    {
+        $property = new ReflectionProperty($staticCache, 'tags');
+        $property->setAccessible(true);
+        $property->setValue($staticCache, $tags);
     }
 }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -124,6 +124,23 @@ class StaticCacheTest extends Unit
         $this->assertNotContains('tag-1000-' . str_repeat('x', 24), $tags);
     }
 
+    public function testCacheTagOverflowKeepsLaterTagsThatFit(): void
+    {
+        $staticCache = new StaticCache();
+        $staticCache->init();
+        $this->setTags($staticCache, Collection::make([
+            StaticCacheTag::create(str_repeat('x', 16 * 1024)),
+            StaticCacheTag::create('second'),
+        ]));
+
+        $this->addCacheHeadersToWebResponse($staticCache);
+
+        $this->assertSame(
+            '123-environment-id:overflow,second',
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value),
+        );
+    }
+
     public function testPurgeTagsIncludeOverflowFallbackTag(): void
     {
         $staticCache = new StaticCache();

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -124,7 +124,7 @@ class StaticCacheTest extends Unit
         $this->assertNotContains('tag-1000-' . str_repeat('x', 24), $tags);
     }
 
-    public function testCacheTagOverflowKeepsLaterTagsThatFit(): void
+    public function testCacheTagOverflowTruncatesRemainingTags(): void
     {
         $staticCache = new StaticCache();
         $staticCache->init();
@@ -136,7 +136,7 @@ class StaticCacheTest extends Unit
         $this->addCacheHeadersToWebResponse($staticCache);
 
         $this->assertSame(
-            '123-environment-id:overflow,second',
+            '123-environment-id:overflow',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value),
         );
     }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -109,7 +109,6 @@ class StaticCacheTest extends Unit
     public function testCacheTagOverflowUsesFallbackTag(): void
     {
         $staticCache = new StaticCache();
-        $staticCache->init();
         $this->setTags($staticCache, Collection::range(1, 1000)
             ->map(fn(int $index) => StaticCacheTag::create("tag-$index-" . str_repeat('x', 24))));
 
@@ -127,7 +126,6 @@ class StaticCacheTest extends Unit
     public function testCacheTagOverflowTruncatesTagsThatExceedTheMaximumLength(): void
     {
         $staticCache = new StaticCache();
-        $staticCache->init();
         $this->setTags($staticCache, Collection::make([
             StaticCacheTag::create(str_repeat('x', 1025)),
             StaticCacheTag::create('second'),
@@ -144,7 +142,6 @@ class StaticCacheTest extends Unit
     public function testCacheTagAtMaximumLengthIsAddedToTheHeader(): void
     {
         $staticCache = new StaticCache();
-        $staticCache->init();
         $tag = str_repeat('x', 1024);
         $this->setTags($staticCache, Collection::make([
             StaticCacheTag::create($tag),
@@ -161,7 +158,6 @@ class StaticCacheTest extends Unit
     public function testCacheTagOverflowTruncatesTagsThatExceedTheMaximumCount(): void
     {
         $staticCache = new StaticCache();
-        $staticCache->init();
         $this->setTags($staticCache, Collection::range(1, 1001)
             ->map(fn(int $index) => StaticCacheTag::create("tag-$index")));
 
@@ -191,7 +187,6 @@ class StaticCacheTest extends Unit
     public function testExistingCacheTagHeaderIsSplit(): void
     {
         $staticCache = new StaticCache();
-        $staticCache->init();
         Craft::$app->getResponse()->getHeaders()->set(HeaderEnum::CACHE_TAG->value, '0, , second');
 
         $this->addCacheHeadersToWebResponse($staticCache);

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -175,7 +175,7 @@ class StaticCacheTest extends Unit
         $this->assertNotContains('tag-1000', $tags);
     }
 
-    public function testPurgeTagsIncludeOverflowFallbackTag(): void
+    public function testPurgeTagsKeepExistingHeaderTags(): void
     {
         $staticCache = new StaticCache();
         Craft::$app->getResponse()->getHeaders()->set(HeaderEnum::CACHE_PURGE_TAG->value, 'first,second');
@@ -183,7 +183,7 @@ class StaticCacheTest extends Unit
         $staticCache->purgeTags();
 
         $this->assertSame(
-            '123-environment-id:overflow,first,second',
+            'first,second',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
     }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -141,12 +141,12 @@ class StaticCacheTest extends Unit
     {
         $staticCache = new StaticCache();
         $staticCache->init();
-        Craft::$app->getResponse()->getHeaders()->set(HeaderEnum::CACHE_TAG->value, 'first,second');
+        Craft::$app->getResponse()->getHeaders()->set(HeaderEnum::CACHE_TAG->value, '0, , second');
 
         $this->addCacheHeadersToWebResponse($staticCache);
 
         $this->assertSame(
-            'first,second',
+            '0,second',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_TAG->value),
         );
     }


### PR DESCRIPTION
Keeps cache-tagged responses within Cloudflare's limits while preserving invalidation with the overflow tag.

The Gateway purges the overflow tag with every cache-tag purge. Overflow fallback is logged at info level because invalidation remains safe.