### PR TITLE
Add static cache purge commands

### DIFF
--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -195,8 +195,8 @@ class StaticCache extends \yii\base\Component
     private function handleRegisterCacheOptions(RegisterCacheOptionsEvent $event): void
     {
         $event->options[] = [
-            'key' => 'craft-cloud-caches',
-            'label' => Craft::t('app', 'Craft Cloud caches'),
+            'key' => 'craft-cloud-static-cache',
+            'label' => Craft::t('app', 'Craft Cloud static cache'),
             'action' => [$this, 'purgeAll'],
         ];
     }

--- a/src/cli/controllers/StaticCacheController.php
+++ b/src/cli/controllers/StaticCacheController.php
@@ -4,10 +4,47 @@ namespace craft\cloud\cli\controllers;
 
 use craft\cloud\Module;
 use craft\console\Controller;
+use yii\console\Exception;
 use yii\console\ExitCode;
 
 class StaticCacheController extends Controller
 {
+    public function actionPurgeAll(): int
+    {
+        $this->do('Purging static cache', function() {
+            $module = Module::getInstance();
+            $environmentId = $this->environmentId();
+            $module->getStaticCache()->purgeTags(
+                "$environmentId:uri",
+                "$environmentId:cdn",
+            );
+        });
+
+        return ExitCode::OK;
+    }
+
+    public function actionPurgeCdn(): int
+    {
+        $this->do('Purging CDN static cache', function() {
+            $module = Module::getInstance();
+            $environmentId = $this->environmentId();
+            $module->getStaticCache()->purgeTags("$environmentId:cdn");
+        });
+
+        return ExitCode::OK;
+    }
+
+    public function actionPurgeOrigin(): int
+    {
+        $this->do('Purging origin static cache', function() {
+            $module = Module::getInstance();
+            $environmentId = $this->environmentId();
+            $module->getStaticCache()->purgeTags("$environmentId:uri");
+        });
+
+        return ExitCode::OK;
+    }
+
     public function actionPurgePrefixes(string ...$prefixes): int
     {
         $this->do('Purging prefixes', function() use ($prefixes) {
@@ -24,5 +61,15 @@ class StaticCacheController extends Controller
         });
 
         return ExitCode::OK;
+    }
+
+    private function environmentId(): string
+    {
+        $environmentId = Module::getInstance()->getConfig()->environmentId;
+        if (!$environmentId) {
+            throw new Exception('Static cache purges require an environment ID.');
+        }
+
+        return $environmentId;
     }
 }

--- a/tests/unit/StaticCacheControllerTest.php
+++ b/tests/unit/StaticCacheControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace craft\cloud\tests\unit;
+
+use Codeception\Test\Unit;
+use Craft;
+use craft\cloud\cli\controllers\StaticCacheController;
+use craft\cloud\Module;
+use craft\cloud\StaticCache;
+use craft\cloud\StaticCacheTag;
+
+class StaticCacheControllerTest extends Unit
+{
+    private ?Module $previousModule = null;
+    private TestStaticCache $staticCache;
+
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->previousModule = Module::getInstance();
+        $module = new Module('cloud');
+        $module->getConfig()->environmentId = '123-environment-id';
+        $this->staticCache = new TestStaticCache();
+        $module->set('staticCache', $this->staticCache);
+        Module::setInstance($module);
+    }
+
+    protected function _after(): void
+    {
+        Module::setInstance($this->previousModule);
+
+        parent::_after();
+    }
+
+    public function testPurgeActions(): void
+    {
+        $controller = new StaticCacheController('static-cache', Craft::$app);
+
+        $controller->actionPurgeAll();
+        $controller->actionPurgeOrigin();
+        $controller->actionPurgeCdn();
+
+        $this->assertSame([
+            ['123-environment-id:uri', '123-environment-id:cdn'],
+            ['123-environment-id:uri'],
+            ['123-environment-id:cdn'],
+        ], $this->staticCache->purges);
+    }
+
+    public function testPurgeFailurePropagates(): void
+    {
+        $this->staticCache->fail = true;
+        $this->expectException(\RuntimeException::class);
+
+        (new StaticCacheController('static-cache', Craft::$app))->actionPurgeAll();
+    }
+
+    public function testPurgeRequiresEnvironmentId(): void
+    {
+        Module::getInstance()->getConfig()->environmentId = null;
+        $this->expectException(\yii\console\Exception::class);
+        $this->expectExceptionMessage('Static cache purges require an environment ID.');
+
+        (new StaticCacheController('static-cache', Craft::$app))->actionPurgeAll();
+    }
+
+    public function testPurgeRequiresNonEmptyEnvironmentId(): void
+    {
+        Module::getInstance()->getConfig()->environmentId = '';
+        $this->expectException(\yii\console\Exception::class);
+        $this->expectExceptionMessage('Static cache purges require an environment ID.');
+
+        (new StaticCacheController('static-cache', Craft::$app))->actionPurgeAll();
+    }
+}
+
+class TestStaticCache extends StaticCache
+{
+    public array $purges = [];
+    public bool $fail = false;
+
+    public function purgeTags(string|StaticCacheTag ...$tags): void
+    {
+        if ($this->fail) {
+            throw new \RuntimeException('Purge failed.');
+        }
+
+        $this->purges[] = $tags;
+    }
+}


### PR DESCRIPTION
Adds explicit `cloud/static-cache/purge-all`, `cloud/static-cache/purge-cdn`, and `cloud/static-cache/purge-origin` commands. Purges run synchronously with the environment-first URI/CDN tags introduced by [#191](https://github.com/craftcms/cloud/pull/191), so gateway failures fail the command.