### PR TITLE
Namespace cache purge tags by environment

### DIFF
--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -28,7 +28,7 @@ use yii\caching\TagDependency;
  *
  * - Added by the gateway:
  *   - `{environmentId}` (legacy)
- *   - `{environmentId}:{uri}` (legacy; URI has a leading and no trailing slash)
+ *   - `{environmentId}:{uri}` (legacy; homepage URI is empty, otherwise leading with no trailing slash)
  *   - `origin:{environmentId}`
  *   - `origin:{environmentId}:{uri}` (URI has a leading and no trailing slash)
  * - Added by the CDN:
@@ -266,13 +266,15 @@ class StaticCache extends \yii\base\Component
             return false;
         }
 
-        $uri = $element->getIsHomepage()
+        $isHomepage = $element->getIsHomepage();
+        $uri = $isHomepage
             ? '/'
             : Path::new($uri)->withLeadingSlash()->withoutTrailingSlash();
 
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        // Purge the legacy unnamespaced URI tag alongside the origin tag.
-        $tags = $this->beforePurge($element, "$environmentId:$uri", "origin:$environmentId:$uri");
+        // Legacy URI tags used an empty homepage URI.
+        $legacyTag = $isHomepage ? "$environmentId:" : "$environmentId:$uri";
+        $tags = $this->beforePurge($element, $legacyTag, "origin:$environmentId:$uri");
         $this->tagsToPurge = $tags->concat($this->tagsToPurge);
 
         return $tags->isNotEmpty();

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -28,9 +28,9 @@ use yii\caching\TagDependency;
  *
  * - Added by the gateway:
  *   - `{environmentId}` (legacy)
- *   - `{environmentId}:{uri}` (legacy; homepage URI is empty, otherwise leading with no trailing slash)
+ *   - `{environmentId}:{uri}` (legacy; homepage URI is empty, otherwise with a leading and no trailing slash)
  *   - `origin:{environmentId}`
- *   - `origin:{environmentId}:{uri}` (homepage URI is `/`, otherwise leading with no trailing slash)
+ *   - `origin:{environmentId}:{uri}` (homepage URI is `/`, otherwise with a leading and no trailing slash)
  * - Added by the CDN:
  *    - `cdn:{environmentId}`
  *    - `cdn:{environmentId}:{objectKey}` (object key has no leading slash)

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -28,7 +28,7 @@ use yii\caching\TagDependency;
  *
  * - Added by the gateway:
  *   - `{environmentId}` (legacy)
- *   - `{environmentId}:{uri}` (legacy; homepage URI is empty, otherwise with a leading and no trailing slash)
+ *   - `{environmentId}:{uri}` (legacy; non-homepage URI has a leading and no trailing slash)
  *   - `origin:{environmentId}`
  *   - `origin:{environmentId}:{uri}` (homepage URI is `/`, otherwise with a leading and no trailing slash)
  * - Added by the CDN:
@@ -272,9 +272,11 @@ class StaticCache extends \yii\base\Component
             : Path::new($uri)->withLeadingSlash()->withoutTrailingSlash();
 
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        // Legacy URI tags used an empty homepage URI.
-        $legacyTag = $isHomepage ? "$environmentId:" : "$environmentId:$uri";
-        $tags = $this->beforePurge($element, $legacyTag, "origin:$environmentId:$uri");
+        // Keep the legacy unnamespaced tag for non-homepage URIs during rollout.
+        $tagValues = $isHomepage
+            ? ["origin:$environmentId:$uri"]
+            : ["$environmentId:$uri", "origin:$environmentId:$uri"];
+        $tags = $this->beforePurge($element, ...$tagValues);
         $this->tagsToPurge = $tags->concat($this->tagsToPurge);
 
         return $tags->isNotEmpty();

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -31,16 +31,14 @@ use yii\caching\TagDependency;
  *   - `{environmentId}:{uri}` (legacy; non-homepage URI has a leading and no trailing slash)
  *   - `{environmentId}:uri`
  *   - `{environmentId}:uri:{uri}` (homepage URI is `/`, otherwise with a leading and no trailing slash)
- *   - `{environmentId}:uri:overflow` (when the URI selector is too long)
  * - Added by the CDN:
  *   - `cdn:{environmentId}` (legacy)
  *   - `cdn:{environmentId}:{objectKey}` (legacy; object key has no leading slash)
  *   - `{environmentId}:cdn`
  *   - `{environmentId}:cdn:{objectKey}` (object key has no leading slash)
- *   - `{environmentId}:cdn:overflow` (when the object key selector is too long)
  * - Added by Craft:
  *   - `{environmentShortId}{hashed}`
- *   - `{environmentId}:overflow` (shared overflow and legacy CDN selector fallback)
+ *   - `{environmentId}:overflow` (when the response has too many tags or a selector is too long)
  */
 class StaticCache extends \yii\base\Component
 {
@@ -283,7 +281,7 @@ class StaticCache extends \yii\base\Component
         $tagValues = $isHomepage
             ? [StaticCacheTag::create("$environmentId:uri:$uri")]
             : [StaticCacheTag::create("$environmentId:$uri"), StaticCacheTag::create("$environmentId:uri:$uri")];
-        $overflowTag = StaticCacheTag::create("$environmentId:uri:overflow");
+        $overflowTag = $this->overflowTag();
         $tags = $this->beforePurge(
             $element,
             ...array_map(

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -29,11 +29,13 @@ use yii\caching\TagDependency;
  * - Added by the gateway:
  *   - `{environmentId}` (legacy)
  *   - `{environmentId}:{uri}` (legacy; non-homepage URI has a leading and no trailing slash)
- *   - `origin:{environmentId}`
- *   - `origin:{environmentId}:{uri}` (homepage URI is `/`, otherwise with a leading and no trailing slash)
+ *   - `{environmentId}:uri`
+ *   - `{environmentId}:uri:{uri}` (homepage URI is `/`, otherwise with a leading and no trailing slash)
  * - Added by the CDN:
- *    - `cdn:{environmentId}`
- *    - `cdn:{environmentId}:{objectKey}` (object key has no leading slash)
+ *   - `cdn:{environmentId}` (legacy)
+ *   - `cdn:{environmentId}:{objectKey}` (legacy; object key has no leading slash)
+ *   - `{environmentId}:cdn`
+ *   - `{environmentId}:cdn:{objectKey}` (object key has no leading slash)
  * - Added by Craft:
  *   - `{environmentShortId}{hashed}`
  *   - `{environmentId}:overflow` (when the response has too many cache tags)
@@ -228,11 +230,11 @@ class StaticCache extends \yii\base\Component
     public function purgeOrigin(): void
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        // Purge the legacy unnamespaced tag alongside the origin tag.
+        // Purge the legacy unscoped tag alongside the URI-family tag.
         $tags = $this->beforePurge(
             null,
             $environmentId,
-            "origin:$environmentId",
+            "$environmentId:uri",
         );
         $this->tagsToPurge->push(...$tags);
     }
@@ -251,9 +253,12 @@ class StaticCache extends \yii\base\Component
 
     public function purgeCdn(): void
     {
+        $environmentId = Module::getInstance()->getConfig()->environmentId;
+        // Purge the legacy cache-family-first tag alongside the environment-first tag.
         $tags = $this->beforePurge(
             null,
-            self::CDN_PREFIX . Module::getInstance()->getConfig()->environmentId,
+            self::CDN_PREFIX . $environmentId,
+            "$environmentId:cdn",
         );
         $this->tagsToPurge->push(...$tags);
     }
@@ -274,8 +279,8 @@ class StaticCache extends \yii\base\Component
         $environmentId = Module::getInstance()->getConfig()->environmentId;
         // Keep the legacy unnamespaced tag for non-homepage URIs during rollout.
         $tagValues = $isHomepage
-            ? ["origin:$environmentId:$uri"]
-            : ["$environmentId:$uri", "origin:$environmentId:$uri"];
+            ? ["$environmentId:uri:$uri"]
+            : ["$environmentId:$uri", "$environmentId:uri:$uri"];
         $tags = $this->beforePurge($element, ...$tagValues);
         $this->tagsToPurge = $tags->concat($this->tagsToPurge);
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -31,16 +31,16 @@ use yii\caching\TagDependency;
  *   - `{environmentId}:{uri}` (legacy; non-homepage URI has a leading and no trailing slash)
  *   - `{environmentId}:uri`
  *   - `{environmentId}:uri:{uri}` (homepage URI is `/`, otherwise with a leading and no trailing slash)
- *   - `{environmentId}:uri:overflow`
+ *   - `{environmentId}:uri:overflow` (when the URI selector is too long)
  * - Added by the CDN:
  *   - `cdn:{environmentId}` (legacy)
  *   - `cdn:{environmentId}:{objectKey}` (legacy; object key has no leading slash)
  *   - `{environmentId}:cdn`
  *   - `{environmentId}:cdn:{objectKey}` (object key has no leading slash)
- *   - `{environmentId}:cdn:overflow`
+ *   - `{environmentId}:cdn:overflow` (when the object key selector is too long)
  * - Added by Craft:
  *   - `{environmentShortId}{hashed}`
- *   - `{environmentId}:overflow` (when the response has too many cache tags)
+ *   - `{environmentId}:overflow` (shared overflow and legacy CDN selector fallback)
  */
 class StaticCache extends \yii\base\Component
 {
@@ -57,7 +57,7 @@ class StaticCache extends \yii\base\Component
      * @see https://developers.cloudflare.com/workers/cache/configuration/
      */
     private const MAX_TAG_HEADER_VALUE_LENGTH = 16 * 1024;
-    private const MAX_TAG_VALUE_LENGTH = 1024;
+    public const MAX_TAG_VALUE_LENGTH = 1024;
     private const MAX_TAG_COUNT = 1000;
     private ?int $cacheDuration = null;
     private Collection $tags;
@@ -281,9 +281,16 @@ class StaticCache extends \yii\base\Component
         $environmentId = Module::getInstance()->getConfig()->environmentId;
         // Keep the legacy unnamespaced tag for non-homepage URIs during rollout.
         $tagValues = $isHomepage
-            ? ["$environmentId:uri:$uri"]
-            : ["$environmentId:$uri", "$environmentId:uri:$uri"];
-        $tags = $this->beforePurge($element, ...$tagValues);
+            ? [StaticCacheTag::create("$environmentId:uri:$uri")]
+            : [StaticCacheTag::create("$environmentId:$uri"), StaticCacheTag::create("$environmentId:uri:$uri")];
+        $overflowTag = StaticCacheTag::create("$environmentId:uri:overflow");
+        $tags = $this->beforePurge(
+            $element,
+            ...array_map(
+                fn(StaticCacheTag $tag) => strlen($tag->getValue()) > self::MAX_TAG_VALUE_LENGTH ? $overflowTag : $tag,
+                $tagValues,
+            ),
+        );
         $this->tagsToPurge = $tags->concat($this->tagsToPurge);
 
         return $tags->isNotEmpty();

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -42,8 +42,6 @@ use yii\caching\TagDependency;
  */
 class StaticCache extends \yii\base\Component
 {
-    public const CDN_PREFIX = 'cdn:';
-
     /**
      * @event PurgeEvent The event that is triggered before static cache tags are purged.
      */
@@ -230,10 +228,8 @@ class StaticCache extends \yii\base\Component
     public function purgeOrigin(): void
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        // Purge the legacy unscoped tag alongside the URI-family tag.
         $tags = $this->beforePurge(
             null,
-            $environmentId,
             "$environmentId:uri",
         );
         $this->tagsToPurge->push(...$tags);
@@ -254,10 +250,8 @@ class StaticCache extends \yii\base\Component
     public function purgeCdn(): void
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        // Purge the legacy cache-family-first tag alongside the environment-first tag.
         $tags = $this->beforePurge(
             null,
-            self::CDN_PREFIX . $environmentId,
             "$environmentId:cdn",
         );
         $this->tagsToPurge->push(...$tags);
@@ -271,23 +265,16 @@ class StaticCache extends \yii\base\Component
             return false;
         }
 
-        $isHomepage = $element->getIsHomepage();
-        $uri = $isHomepage
+        $uri = $element->getIsHomepage()
             ? '/'
             : Path::new($uri)->withLeadingSlash()->withoutTrailingSlash();
 
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        // Keep the legacy unnamespaced tag for non-homepage URIs during rollout.
-        $tagValues = $isHomepage
-            ? [StaticCacheTag::create("$environmentId:uri:$uri")]
-            : [StaticCacheTag::create("$environmentId:$uri"), StaticCacheTag::create("$environmentId:uri:$uri")];
+        $tag = StaticCacheTag::create("$environmentId:uri:$uri");
         $overflowTag = $this->overflowTag();
         $tags = $this->beforePurge(
             $element,
-            ...array_map(
-                fn(StaticCacheTag $tag) => strlen($tag->getValue()) > self::MAX_TAG_VALUE_LENGTH ? $overflowTag : $tag,
-                $tagValues,
-            ),
+            strlen($tag->getValue()) > self::MAX_TAG_VALUE_LENGTH ? $overflowTag : $tag,
         );
         $this->tagsToPurge = $tags->concat($this->tagsToPurge);
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -27,8 +27,10 @@ use yii\caching\TagDependency;
  * The values are comma-separated and can be in several formats:
  *
  * - Added by the gateway:
- *   - `{environmentId}`
- *   - `{environmentId}:{uri}` (URI has a leading and no trailing slash)
+ *   - `{environmentId}` (legacy)
+ *   - `{environmentId}:{uri}` (legacy; URI has a leading and no trailing slash)
+ *   - `origin:{environmentId}`
+ *   - `origin:{environmentId}:{uri}` (URI has a leading and no trailing slash)
  * - Added by the CDN:
  *    - `cdn:{environmentId}`
  *    - `cdn:{environmentId}:{objectKey}` (object key has no leading slash)
@@ -225,9 +227,12 @@ class StaticCache extends \yii\base\Component
 
     public function purgeOrigin(): void
     {
+        $environmentId = Module::getInstance()->getConfig()->environmentId;
+        // Purge the legacy unnamespaced tag alongside the origin tag.
         $tags = $this->beforePurge(
             null,
-            Module::getInstance()->getConfig()->environmentId,
+            $environmentId,
+            "origin:$environmentId",
         );
         $this->tagsToPurge->push(...$tags);
     }
@@ -266,7 +271,8 @@ class StaticCache extends \yii\base\Component
             : Path::new($uri)->withLeadingSlash()->withoutTrailingSlash();
 
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        $tags = $this->beforePurge($element, "$environmentId:$uri");
+        // Purge the legacy unnamespaced URI tag alongside the origin tag.
+        $tags = $this->beforePurge($element, "$environmentId:$uri", "origin:$environmentId:$uri");
         $this->tagsToPurge = $tags->concat($this->tagsToPurge);
 
         return $tags->isNotEmpty();

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -31,11 +31,13 @@ use yii\caching\TagDependency;
  *   - `{environmentId}:{uri}` (legacy; non-homepage URI has a leading and no trailing slash)
  *   - `{environmentId}:uri`
  *   - `{environmentId}:uri:{uri}` (homepage URI is `/`, otherwise with a leading and no trailing slash)
+ *   - `{environmentId}:uri:overflow`
  * - Added by the CDN:
  *   - `cdn:{environmentId}` (legacy)
  *   - `cdn:{environmentId}:{objectKey}` (legacy; object key has no leading slash)
  *   - `{environmentId}:cdn`
  *   - `{environmentId}:cdn:{objectKey}` (object key has no leading slash)
+ *   - `{environmentId}:cdn:overflow`
  * - Added by Craft:
  *   - `{environmentShortId}{hashed}`
  *   - `{environmentId}:overflow` (when the response has too many cache tags)

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -30,7 +30,7 @@ use yii\caching\TagDependency;
  *   - `{environmentId}` (legacy)
  *   - `{environmentId}:{uri}` (legacy; homepage URI is empty, otherwise leading with no trailing slash)
  *   - `origin:{environmentId}`
- *   - `origin:{environmentId}:{uri}` (URI has a leading and no trailing slash)
+ *   - `origin:{environmentId}:{uri}` (homepage URI is `/`, otherwise leading with no trailing slash)
  * - Added by the CDN:
  *    - `cdn:{environmentId}`
  *    - `cdn:{environmentId}:{objectKey}` (object key has no leading slash)

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -9,7 +9,6 @@ use Craft;
 use craft\behaviors\EnvAttributeParserBehavior;
 use craft\cloud\Module;
 use craft\cloud\StaticCache;
-use craft\cloud\StaticCacheTag;
 use craft\elements\Asset;
 use craft\errors\FsException;
 use craft\flysystem\base\FlysystemFs;
@@ -202,12 +201,14 @@ abstract class Fs extends FlysystemFs
     protected function invalidateCdnPath(string $path): bool
     {
         try {
-            $prefix = StaticCache::CDN_PREFIX . Module::getInstance()->getConfig()->environmentId . ':';
-            $tag = StaticCacheTag::create($this->createBucketPath($path)->toString())
-                ->minify(false)
-                ->withPrefix($prefix);
+            $environmentId = Module::getInstance()->getConfig()->environmentId;
+            $objectKey = $this->createBucketPath($path)->toString();
 
-            Module::getInstance()->getStaticCache()->purgeTags($tag);
+            // Purge the legacy cache-family-first tag alongside the environment-first tag.
+            Module::getInstance()->getStaticCache()->purgeTags(
+                StaticCache::CDN_PREFIX . "$environmentId:$objectKey",
+                "$environmentId:cdn:$objectKey",
+            );
 
             return true;
         } catch (\Throwable $e) {

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -9,6 +9,7 @@ use Craft;
 use craft\behaviors\EnvAttributeParserBehavior;
 use craft\cloud\Module;
 use craft\cloud\StaticCache;
+use craft\cloud\StaticCacheTag;
 use craft\elements\Asset;
 use craft\errors\FsException;
 use craft\flysystem\base\FlysystemFs;
@@ -203,11 +204,13 @@ abstract class Fs extends FlysystemFs
         try {
             $environmentId = Module::getInstance()->getConfig()->environmentId;
             $objectKey = $this->createBucketPath($path)->toString();
+            $legacyTag = StaticCacheTag::create(StaticCache::CDN_PREFIX . "$environmentId:$objectKey");
+            $cdnTag = StaticCacheTag::create("$environmentId:cdn:$objectKey");
 
             // Purge the legacy cache-family-first tag alongside the environment-first tag.
             Module::getInstance()->getStaticCache()->purgeTags(
-                StaticCache::CDN_PREFIX . "$environmentId:$objectKey",
-                "$environmentId:cdn:$objectKey",
+                strlen($legacyTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH ? "$environmentId:overflow" : $legacyTag,
+                strlen($cdnTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH ? "$environmentId:cdn:overflow" : $cdnTag,
             );
 
             return true;

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -210,7 +210,7 @@ abstract class Fs extends FlysystemFs
             // Purge the legacy cache-family-first tag alongside the environment-first tag.
             Module::getInstance()->getStaticCache()->purgeTags(
                 strlen($legacyTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH ? "$environmentId:overflow" : $legacyTag,
-                strlen($cdnTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH ? "$environmentId:cdn:overflow" : $cdnTag,
+                strlen($cdnTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH ? "$environmentId:overflow" : $cdnTag,
             );
 
             return true;

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -204,12 +204,9 @@ abstract class Fs extends FlysystemFs
         try {
             $environmentId = Module::getInstance()->getConfig()->environmentId;
             $objectKey = $this->createBucketPath($path)->toString();
-            $legacyTag = StaticCacheTag::create(StaticCache::CDN_PREFIX . "$environmentId:$objectKey");
             $cdnTag = StaticCacheTag::create("$environmentId:cdn:$objectKey");
 
-            // Purge the legacy cache-family-first tag alongside the environment-first tag.
             Module::getInstance()->getStaticCache()->purgeTags(
-                strlen($legacyTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH ? "$environmentId:overflow" : $legacyTag,
                 strlen($cdnTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH ? "$environmentId:overflow" : $cdnTag,
             );
 

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -218,6 +218,20 @@ class StaticCacheTest extends Unit
         );
     }
 
+    public function testPurgeAllUsesOriginAndCdnTags(): void
+    {
+        $staticCache = new StaticCache();
+
+        $staticCache->purgeAll();
+
+        $this->assertSame(
+            ['123-environment-id', 'origin:123-environment-id', 'cdn:123-environment-id'],
+            $this->collectionProperty($staticCache, 'tagsToPurge')
+                ->map(fn(StaticCacheTag $tag) => $tag->getValue())
+                ->all(),
+        );
+    }
+
     public function testBeforePurgeEventCanCancelPurge(): void
     {
         $staticCache = new StaticCache();
@@ -266,7 +280,7 @@ class StaticCacheTest extends Unit
         }
 
         $this->assertSame(
-            '123-environment-id:/news',
+            '123-environment-id:/news,origin:123-environment-id:/news',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
     }
@@ -313,7 +327,10 @@ class StaticCacheTest extends Unit
         $this->saveElement($staticCache, $element);
 
         $this->assertSame($element, $purgeEvent->element);
-        $this->assertSame('123-environment-id:/news', $purgeEvent->tags[0]->getValue());
+        $this->assertSame(
+            ['123-environment-id:/news', 'origin:123-environment-id:/news'],
+            array_map(fn(StaticCacheTag $tag) => $tag->getValue(), $purgeEvent->tags),
+        );
     }
 
     public function testCancelledElementPurgeDoesNotQueueFetch(): void
@@ -369,7 +386,10 @@ class StaticCacheTest extends Unit
             flags: JSON_THROW_ON_ERROR,
         );
 
-        $this->assertSame(['123-environment-id:/news'], $payload['tags']);
+        $this->assertSame([
+            '123-environment-id:/news',
+            'origin:123-environment-id:/news',
+        ], $payload['tags']);
         $this->assertSame([
             'https://example.com/news',
             'https://example.com/fr/nouvelles',

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -226,14 +226,14 @@ class StaticCacheTest extends Unit
         $staticCache->purgeAll();
 
         $this->assertSame(
-            ['123-environment-id', '123-environment-id:uri', 'cdn:123-environment-id', '123-environment-id:cdn'],
+            ['123-environment-id:uri', '123-environment-id:cdn'],
             $this->collectionProperty($staticCache, 'tagsToPurge')
                 ->map(fn(StaticCacheTag $tag) => $tag->getValue())
                 ->all(),
         );
     }
 
-    public function testAssetCdnPurgeUsesLegacyAndEnvironmentFirstTags(): void
+    public function testAssetCdnPurgeUsesEnvironmentFirstTag(): void
     {
         $staticCache = new StaticCache();
         Module::getInstance()->set('staticCache', $staticCache);
@@ -243,7 +243,7 @@ class StaticCacheTest extends Unit
 
         $this->assertTrue($method->invoke($fs, 'image.jpg'));
         $this->assertSame(
-            'cdn:123-environment-id:123-environment-id/assets/image.jpg,123-environment-id:cdn:123-environment-id/assets/image.jpg',
+            '123-environment-id:cdn:123-environment-id/assets/image.jpg',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
     }
@@ -311,7 +311,7 @@ class StaticCacheTest extends Unit
         }
 
         $this->assertSame(
-            '123-environment-id:/news,123-environment-id:uri:/news',
+            '123-environment-id:uri:/news',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
     }
@@ -359,7 +359,7 @@ class StaticCacheTest extends Unit
 
         $this->assertSame($element, $purgeEvent->element);
         $this->assertSame(
-            ['123-environment-id:/news', '123-environment-id:uri:/news'],
+            ['123-environment-id:uri:/news'],
             array_map(fn(StaticCacheTag $tag) => $tag->getValue(), $purgeEvent->tags),
         );
     }
@@ -450,10 +450,7 @@ class StaticCacheTest extends Unit
             flags: JSON_THROW_ON_ERROR,
         );
 
-        $this->assertSame([
-            '123-environment-id:/news',
-            '123-environment-id:uri:/news',
-        ], $payload['tags']);
+        $this->assertSame(['123-environment-id:uri:/news'], $payload['tags']);
         $this->assertSame([
             'https://example.com/news',
             'https://example.com/fr/nouvelles',

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -333,7 +333,7 @@ class StaticCacheTest extends Unit
         );
     }
 
-    public function testHomepagePurgeUsesLegacyEmptyUriTag(): void
+    public function testHomepagePurgeUsesOriginTag(): void
     {
         $staticCache = new StaticCache();
         $element = new Entry(['uri' => Entry::HOMEPAGE_URI]);
@@ -341,7 +341,7 @@ class StaticCacheTest extends Unit
         $this->saveElement($staticCache, $element);
 
         $this->assertSame(
-            ['123-environment-id:', 'origin:123-environment-id:/'],
+            ['origin:123-environment-id:/'],
             $this->collectionProperty($staticCache, 'tagsToPurge')
                 ->map(fn(StaticCacheTag $tag) => $tag->getValue())
                 ->all(),

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -248,7 +248,7 @@ class StaticCacheTest extends Unit
         );
     }
 
-    public function testOverlongAssetCdnPurgeUsesOverflowTags(): void
+    public function testOverlongAssetCdnPurgeUsesOverflowTag(): void
     {
         $staticCache = new StaticCache();
         Module::getInstance()->set('staticCache', $staticCache);
@@ -258,7 +258,7 @@ class StaticCacheTest extends Unit
 
         $this->assertTrue($method->invoke($fs, str_repeat('x', 1024)));
         $this->assertSame(
-            '123-environment-id:overflow,123-environment-id:cdn:overflow',
+            '123-environment-id:overflow',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
     }
@@ -394,7 +394,7 @@ class StaticCacheTest extends Unit
             flags: JSON_THROW_ON_ERROR,
         );
 
-        $this->assertSame(['123-environment-id:uri:overflow'], $payload['tags']);
+        $this->assertSame(['123-environment-id:overflow'], $payload['tags']);
     }
 
     public function testCancelledElementPurgeDoesNotQueueFetch(): void

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -239,6 +239,7 @@ class StaticCacheTest extends Unit
         Module::getInstance()->set('staticCache', $staticCache);
         $fs = new AssetsFs();
         $method = new ReflectionMethod($fs, 'invalidateCdnPath');
+        $method->setAccessible(true);
 
         $this->assertTrue($method->invoke($fs, 'image.jpg'));
         $this->assertSame(

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -248,6 +248,21 @@ class StaticCacheTest extends Unit
         );
     }
 
+    public function testOverlongAssetCdnPurgeUsesOverflowTags(): void
+    {
+        $staticCache = new StaticCache();
+        Module::getInstance()->set('staticCache', $staticCache);
+        $fs = new AssetsFs();
+        $method = new ReflectionMethod($fs, 'invalidateCdnPath');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($fs, str_repeat('x', 1024)));
+        $this->assertSame(
+            '123-environment-id:overflow,123-environment-id:cdn:overflow',
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
+        );
+    }
+
     public function testBeforePurgeEventCanCancelPurge(): void
     {
         $staticCache = new StaticCache();
@@ -362,6 +377,24 @@ class StaticCacheTest extends Unit
                 ->map(fn(StaticCacheTag $tag) => $tag->getValue())
                 ->all(),
         );
+    }
+
+    public function testOverlongElementUriPurgeUsesOverflowTag(): void
+    {
+        $staticCache = new StaticCache();
+        $element = new FetchableElement(['uri' => str_repeat('x', 1024)]);
+        $element->fetchUrl = 'https://example.com/overlong';
+
+        $this->saveElement($staticCache, $element);
+        $this->sendPendingPurgeTags($staticCache);
+
+        $payload = json_decode(
+            (string) $this->gatewayRequest?->getBody(),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+
+        $this->assertSame(['123-environment-id:uri:overflow'], $payload['tags']);
     }
 
     public function testCancelledElementPurgeDoesNotQueueFetch(): void

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -5,6 +5,7 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\events\PurgeEvent;
+use craft\cloud\fs\AssetsFs;
 use craft\cloud\HeaderEnum;
 use craft\cloud\Module;
 use craft\cloud\signing\RequestSigner;
@@ -225,10 +226,24 @@ class StaticCacheTest extends Unit
         $staticCache->purgeAll();
 
         $this->assertSame(
-            ['123-environment-id', 'origin:123-environment-id', 'cdn:123-environment-id'],
+            ['123-environment-id', '123-environment-id:uri', 'cdn:123-environment-id', '123-environment-id:cdn'],
             $this->collectionProperty($staticCache, 'tagsToPurge')
                 ->map(fn(StaticCacheTag $tag) => $tag->getValue())
                 ->all(),
+        );
+    }
+
+    public function testAssetCdnPurgeUsesLegacyAndEnvironmentFirstTags(): void
+    {
+        $staticCache = new StaticCache();
+        Module::getInstance()->set('staticCache', $staticCache);
+        $fs = new AssetsFs();
+        $method = new ReflectionMethod($fs, 'invalidateCdnPath');
+
+        $this->assertTrue($method->invoke($fs, 'image.jpg'));
+        $this->assertSame(
+            'cdn:123-environment-id:123-environment-id/assets/image.jpg,123-environment-id:cdn:123-environment-id/assets/image.jpg',
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
     }
 
@@ -280,7 +295,7 @@ class StaticCacheTest extends Unit
         }
 
         $this->assertSame(
-            '123-environment-id:/news,origin:123-environment-id:/news',
+            '123-environment-id:/news,123-environment-id:uri:/news',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
     }
@@ -328,12 +343,12 @@ class StaticCacheTest extends Unit
 
         $this->assertSame($element, $purgeEvent->element);
         $this->assertSame(
-            ['123-environment-id:/news', 'origin:123-environment-id:/news'],
+            ['123-environment-id:/news', '123-environment-id:uri:/news'],
             array_map(fn(StaticCacheTag $tag) => $tag->getValue(), $purgeEvent->tags),
         );
     }
 
-    public function testHomepagePurgeUsesOriginTag(): void
+    public function testHomepagePurgeUsesUriTag(): void
     {
         $staticCache = new StaticCache();
         $element = new Entry(['uri' => Entry::HOMEPAGE_URI]);
@@ -341,7 +356,7 @@ class StaticCacheTest extends Unit
         $this->saveElement($staticCache, $element);
 
         $this->assertSame(
-            ['origin:123-environment-id:/'],
+            ['123-environment-id:uri:/'],
             $this->collectionProperty($staticCache, 'tagsToPurge')
                 ->map(fn(StaticCacheTag $tag) => $tag->getValue())
                 ->all(),
@@ -403,7 +418,7 @@ class StaticCacheTest extends Unit
 
         $this->assertSame([
             '123-environment-id:/news',
-            'origin:123-environment-id:/news',
+            '123-environment-id:uri:/news',
         ], $payload['tags']);
         $this->assertSame([
             'https://example.com/news',

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -333,6 +333,21 @@ class StaticCacheTest extends Unit
         );
     }
 
+    public function testHomepagePurgeUsesLegacyEmptyUriTag(): void
+    {
+        $staticCache = new StaticCache();
+        $element = new Entry(['uri' => Entry::HOMEPAGE_URI]);
+
+        $this->saveElement($staticCache, $element);
+
+        $this->assertSame(
+            ['123-environment-id:', 'origin:123-environment-id:/'],
+            $this->collectionProperty($staticCache, 'tagsToPurge')
+                ->map(fn(StaticCacheTag $tag) => $tag->getValue())
+                ->all(),
+        );
+    }
+
     public function testCancelledElementPurgeDoesNotQueueFetch(): void
     {
         $staticCache = new StaticCache();


### PR DESCRIPTION
Uses environment-first URI and CDN purge tags (`{environmentId}:uri...` and `{environmentId}:cdn...`) with the single `{environmentId}:overflow` fallback for overlong selectors and Craft tag-count overflow.

The package sends only these tags. Rollout legacy aliases remain a gateway concern and are documented here only as cache-entry formats.

Related: [craftcms/cloud-gateway#176](https://github.com/craftcms/cloud-gateway/pull/176)