### PR TITLE
Batch static cache purge tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,6 @@ Most configuration (to Craft and the extension itself) is handled directly by Cl
 
 ### Static cache
 
-The `StaticCache::EVENT_BEFORE_PURGE` event fires once immediately before each collected batch is sent. Listeners can modify its `tags` or cancel the purge.
+The `StaticCache::EVENT_BEFORE_PURGE` event fires immediately before each tag purge, including the collected end-of-request batch. Listeners can modify its `tags` or cancel the purge.
 
 When a saved element purge proceeds, its non-null site URL is included in tag-based gateway API requests as the optional `fetchUrls` field. URLs are deduplicated, and the gateway asynchronously fetches them after a successful purge to repopulate the cache. Drafts, revisions, deletions, and canceled purges do not send URLs.

--- a/README.md
+++ b/README.md
@@ -223,31 +223,6 @@ Most configuration (to Craft and the extension itself) is handled directly by Cl
 
 ### Static cache
 
-Static cache purge events can be configured through Yii’s dependency injection container in `config/app.php`:
-
-```php
-use craft\cloud\events\PurgeEvent;
-use craft\cloud\StaticCache;
-
-return [
-    'container' => [
-        'definitions' => [
-            StaticCache::class => [
-                'class' => StaticCache::class,
-                'on ' . StaticCache::EVENT_BEFORE_PURGE => static function(PurgeEvent $event): void {
-                    foreach ($event->elements as $element) {
-                        if ($element->uri === 'health-check') {
-                            $event->isValid = false;
-                            break;
-                        }
-                    }
-                },
-            ],
-        ],
-    ],
-];
-```
-
-The event fires once immediately before each collected batch is sent. Its `elements` property contains the elements associated with the batch.
+The `StaticCache::EVENT_BEFORE_PURGE` event fires once immediately before each collected batch is sent. Listeners can modify its `tags` or cancel the purge.
 
 When a saved element purge proceeds, its non-null site URL is included in tag-based gateway API requests as the optional `fetchUrls` field. URLs are deduplicated, and the gateway asynchronously fetches them after a successful purge to repopulate the cache. Drafts, revisions, deletions, and canceled purges do not send URLs.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,6 @@ return [
 ];
 ```
 
-The event fires once immediately before each collected batch is sent. Its `elements` property contains the unique elements associated with the batch.
+The event fires once immediately before each collected batch is sent. Its `elements` property contains the elements associated with the batch.
 
 When a saved element purge proceeds, its non-null site URL is included in tag-based gateway API requests as the optional `fetchUrls` field. URLs are deduplicated, and the gateway asynchronously fetches them after a successful purge to repopulate the cache. Drafts, revisions, deletions, and canceled purges do not send URLs.

--- a/README.md
+++ b/README.md
@@ -235,8 +235,11 @@ return [
             StaticCache::class => [
                 'class' => StaticCache::class,
                 'on ' . StaticCache::EVENT_BEFORE_PURGE => static function(PurgeEvent $event): void {
-                    if ($event->element?->uri === 'health-check') {
-                        $event->isValid = false;
+                    foreach ($event->elements as $element) {
+                        if ($element->uri === 'health-check') {
+                            $event->isValid = false;
+                            break;
+                        }
                     }
                 },
             ],
@@ -245,4 +248,6 @@ return [
 ];
 ```
 
-When a saved element purge proceeds, its non-null site URL is included in tag-based gateway API requests as the optional `fetchUrls` field. URLs are deduplicated, and the gateway asynchronously fetches them after a successful purge to repopulate the cache. Drafts, revisions, deletions, and canceled purges do not enqueue URLs.
+The event fires once immediately before each collected batch is sent. Its `elements` property contains the unique elements associated with the batch.
+
+When a saved element purge proceeds, its non-null site URL is included in tag-based gateway API requests as the optional `fetchUrls` field. URLs are deduplicated, and the gateway asynchronously fetches them after a successful purge to repopulate the cache. Drafts, revisions, deletions, and canceled purges do not send URLs.

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -117,7 +117,11 @@ class StaticCache extends \yii\base\Component
         Craft::$app->onAfterRequest(function() {
             if ($this->tagsToPurge->isNotEmpty()) {
                 try {
-                    $this->sendPurgeTagsRequest();
+                    $this->sendPurgeTagsRequest(
+                        $this->tagsToPurge,
+                        $this->elementsToPurge,
+                        $this->fetchUrls,
+                    );
                 } catch (\Throwable $e) {
                     Module::error(
                         'Failed to purge tags after request',
@@ -291,8 +295,7 @@ class StaticCache extends \yii\base\Component
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
     {
-        $this->addPurgeTags($tags);
-        $this->sendPurgeTagsRequest();
+        $this->sendPurgeTagsRequest(Collection::make($tags));
     }
 
     /**
@@ -308,11 +311,13 @@ class StaticCache extends \yii\base\Component
         }
     }
 
-    private function sendPurgeTagsRequest(): void
-    {
+    private function sendPurgeTagsRequest(
+        Collection $tags,
+        ?Collection $elements = null,
+        ?Collection $fetchUrls = null,
+    ): void {
         $response = Craft::$app->getResponse();
         $isWebResponse = $response instanceof \craft\web\Response;
-        $tags = $this->tagsToPurge;
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
@@ -328,7 +333,7 @@ class StaticCache extends \yii\base\Component
 
         $event = new PurgeEvent([
             'tags' => $tags->values()->all(),
-            'elements' => $this->elementsToPurge
+            'elements' => ($elements ?? Collection::make())
                 ->unique(fn(ElementInterface $element) => spl_object_id($element))
                 ->values()
                 ->all(),
@@ -340,15 +345,12 @@ class StaticCache extends \yii\base\Component
                 ->map(fn(StaticCacheTag $tag) => StringHelper::byteLength($tag->getValue()) > self::MAX_TAG_VALUE_LENGTH ? $overflowTag : $tag)
                 ->unique(fn(StaticCacheTag $tag) => $tag->getValue())
             : Collection::make();
-        $fetchUrls = $this->fetchUrls;
-        $this->tagsToPurge = Collection::make();
-        $this->elementsToPurge = Collection::make();
-        $this->fetchUrls = Collection::make();
 
         if ($tags->isEmpty()) {
             return;
         }
 
+        $fetchUrls ??= Collection::make();
         $sendApiRequest = !$isWebResponse || $fetchUrls->isNotEmpty();
 
         if (!$sendApiRequest) {

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -58,6 +58,7 @@ class StaticCache extends \yii\base\Component
     private ?int $cacheDuration = null;
     private Collection $tags;
     private Collection $tagsToPurge;
+    private Collection $elementsToPurge;
     private Collection $fetchUrls;
     private bool $collectingCacheInfo = false;
 
@@ -65,6 +66,7 @@ class StaticCache extends \yii\base\Component
     {
         $this->tags = Collection::make();
         $this->tagsToPurge = Collection::make();
+        $this->elementsToPurge = Collection::make();
         $this->fetchUrls = Collection::make();
     }
 
@@ -115,14 +117,14 @@ class StaticCache extends \yii\base\Component
         Craft::$app->onAfterRequest(function() {
             if ($this->tagsToPurge->isNotEmpty()) {
                 try {
-                    $this->sendTagPurgeRequest(
-                        $this->tagsToPurge,
-                        $this->fetchUrls,
-                    );
+                    $this->sendPurgeTagsRequest();
                 } catch (\Throwable $e) {
-                    Module::error('Failed to purge tags after request', [
-                        'exceptionMessage' => $e->getMessage(),
-                    ]);
+                    Module::error(
+                        'Failed to purge tags after request',
+                        [
+                            'exception' => $e,
+                        ],
+                    );
                 }
             }
         });
@@ -188,8 +190,11 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        $tags = $this->beforePurge($element, ...$tags);
-        $this->tagsToPurge->push(...$tags);
+        $this->addPurgeTags(...$tags);
+
+        if ($element) {
+            $this->elementsToPurge->push($element);
+        }
     }
 
     private function handleRegisterCacheOptions(RegisterCacheOptionsEvent $event): void
@@ -228,11 +233,7 @@ class StaticCache extends \yii\base\Component
     public function purgeOrigin(): void
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        $tags = $this->beforePurge(
-            null,
-            "$environmentId:uri",
-        );
-        $this->tagsToPurge->push(...$tags);
+        $this->addPurgeTags("$environmentId:uri");
     }
 
     /**
@@ -250,11 +251,7 @@ class StaticCache extends \yii\base\Component
     public function purgeCdn(): void
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        $tags = $this->beforePurge(
-            null,
-            "$environmentId:cdn",
-        );
-        $this->tagsToPurge->push(...$tags);
+        $this->addPurgeTags("$environmentId:cdn");
     }
 
     private function purgeElementUri(ElementInterface $element): bool
@@ -271,14 +268,9 @@ class StaticCache extends \yii\base\Component
 
         $environmentId = Module::getInstance()->getConfig()->environmentId;
         $tag = StaticCacheTag::create("$environmentId:uri:$uri");
-        $overflowTag = $this->overflowTag();
-        $tags = $this->beforePurge(
-            $element,
-            strlen($tag->getValue()) > self::MAX_TAG_VALUE_LENGTH ? $overflowTag : $tag,
-        );
-        $this->tagsToPurge = $tags->concat($this->tagsToPurge);
-
-        return $tags->isNotEmpty();
+        $this->addPurgeTags($tag);
+        $this->elementsToPurge->push($element);
+        return true;
     }
 
     private function addCacheHeadersToWebResponse(): void
@@ -304,29 +296,25 @@ class StaticCache extends \yii\base\Component
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
     {
-        $tags = Collection::make($tags);
-        $response = Craft::$app->getResponse();
-
-        if ($response instanceof \craft\web\Response) {
-            $tags->push(...$this->parseCacheTagsFromHeader(HeaderEnum::CACHE_PURGE_TAG->value));
-            $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
-        }
-
-        $tags = $this->beforePurge(null, ...$tags);
-        $this->sendTagPurgeRequest($tags);
+        $this->addPurgeTags(...$tags);
+        $this->sendPurgeTagsRequest();
     }
 
-    private function sendTagPurgeRequest(Collection $tags, ?Collection $fetchUrls = null): void
+    public function addPurgeTags(string|StaticCacheTag ...$tags): void
+    {
+        $this->tagsToPurge->push(...$this->normalizeCacheTags(...$tags));
+    }
+
+    private function sendPurgeTagsRequest(): void
     {
         $response = Craft::$app->getResponse();
         $isWebResponse = $response instanceof \craft\web\Response;
-        $sendApiRequest = !$isWebResponse || $fetchUrls?->isNotEmpty();
+        $tags = $this->tagsToPurge;
 
         // Add any existing tags from the response headers
         if ($isWebResponse) {
-            $headerTags = $this->parseCacheTagsFromHeader(HeaderEnum::CACHE_PURGE_TAG->value);
+            $tags->push(...$this->parseCacheTagsFromHeader(HeaderEnum::CACHE_PURGE_TAG->value));
             $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
-            $tags->push(...$this->beforePurge(null, ...$headerTags));
         }
 
         $tags = $this->normalizeCacheTags(...$tags);
@@ -334,6 +322,31 @@ class StaticCache extends \yii\base\Component
         if ($tags->isEmpty()) {
             return;
         }
+
+        $event = new PurgeEvent([
+            'tags' => $tags->values()->all(),
+            'elements' => $this->elementsToPurge
+                ->unique(fn(ElementInterface $element) => spl_object_id($element))
+                ->values()
+                ->all(),
+        ]);
+        $this->trigger(self::EVENT_BEFORE_PURGE, $event);
+        $overflowTag = $this->overflowTag();
+        $tags = $event->isValid
+            ? $this->normalizeCacheTags(...$event->tags)
+                ->map(fn(StaticCacheTag $tag) => StringHelper::byteLength($tag->getValue()) > self::MAX_TAG_VALUE_LENGTH ? $overflowTag : $tag)
+                ->unique(fn(StaticCacheTag $tag) => $tag->getValue())
+            : Collection::make();
+        $fetchUrls = $this->fetchUrls;
+        $this->tagsToPurge = Collection::make();
+        $this->elementsToPurge = Collection::make();
+        $this->fetchUrls = Collection::make();
+
+        if ($tags->isEmpty()) {
+            return;
+        }
+
+        $sendApiRequest = !$isWebResponse || $fetchUrls->isNotEmpty();
 
         if (!$sendApiRequest) {
             $tags = $this->truncateCacheTagsForHeader($tags);
@@ -359,7 +372,7 @@ class StaticCache extends \yii\base\Component
             'tags' => $tags->map(fn(StaticCacheTag $tag) => (string) $tag)->values()->all(),
         ];
 
-        if ($fetchUrls?->isNotEmpty()) {
+        if ($fetchUrls->isNotEmpty()) {
             $payload['fetchUrls'] = $fetchUrls
                 ->unique()
                 ->values()
@@ -381,30 +394,6 @@ class StaticCache extends \yii\base\Component
 
             throw $e;
         }
-    }
-
-    private function beforePurge(
-        ?ElementInterface $element,
-        string|StaticCacheTag ...$tags,
-    ): Collection {
-        $tags = $this->normalizeCacheTags(...$tags);
-
-        if ($tags->isEmpty()) {
-            return $tags;
-        }
-
-        $event = new PurgeEvent([
-            'tags' => $tags->values()->all(),
-            'element' => $element,
-        ]);
-
-        $this->trigger(self::EVENT_BEFORE_PURGE, $event);
-
-        if (!$event->isValid) {
-            return Collection::make();
-        }
-
-        return Collection::make($event->tags);
     }
 
     public function purgeUrlPrefixes(string ...$urlPrefixes): void

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -190,11 +190,7 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        $this->addPurgeTags(...$tags);
-
-        if ($element) {
-            $this->elementsToPurge->push($element);
-        }
+        $this->addPurgeTags($tags->all(), $element);
     }
 
     private function handleRegisterCacheOptions(RegisterCacheOptionsEvent $event): void
@@ -233,7 +229,7 @@ class StaticCache extends \yii\base\Component
     public function purgeOrigin(): void
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        $this->addPurgeTags("$environmentId:uri");
+        $this->addPurgeTags(["$environmentId:uri"]);
     }
 
     /**
@@ -251,7 +247,7 @@ class StaticCache extends \yii\base\Component
     public function purgeCdn(): void
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        $this->addPurgeTags("$environmentId:cdn");
+        $this->addPurgeTags(["$environmentId:cdn"]);
     }
 
     private function purgeElementUri(ElementInterface $element): bool
@@ -268,8 +264,7 @@ class StaticCache extends \yii\base\Component
 
         $environmentId = Module::getInstance()->getConfig()->environmentId;
         $tag = StaticCacheTag::create("$environmentId:uri:$uri");
-        $this->addPurgeTags($tag);
-        $this->elementsToPurge->push($element);
+        $this->addPurgeTags([$tag], $element);
         return true;
     }
 
@@ -296,13 +291,21 @@ class StaticCache extends \yii\base\Component
 
     public function purgeTags(string|StaticCacheTag ...$tags): void
     {
-        $this->addPurgeTags(...$tags);
+        $this->addPurgeTags($tags);
         $this->sendPurgeTagsRequest();
     }
 
-    public function addPurgeTags(string|StaticCacheTag ...$tags): void
+    /**
+     * @param array<array-key, string|StaticCacheTag> $tags
+     */
+    public function addPurgeTags(array $tags, ?ElementInterface $element = null): void
     {
-        $this->tagsToPurge->push(...$this->normalizeCacheTags(...$tags));
+        $tags = $this->normalizeCacheTags(...$tags);
+        $this->tagsToPurge->push(...$tags);
+
+        if ($element && $tags->isNotEmpty()) {
+            $this->elementsToPurge->push($element);
+        }
     }
 
     private function sendPurgeTagsRequest(): void

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -313,7 +313,6 @@ class StaticCache extends \yii\base\Component
         // Add any existing tags from the response headers
         if ($isWebResponse) {
             $tags->push(...$this->parseCacheTagsFromHeader(HeaderEnum::CACHE_PURGE_TAG->value));
-            $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
         }
 
         $tags = $this->normalizeCacheTags(...$tags);
@@ -326,6 +325,11 @@ class StaticCache extends \yii\base\Component
             'tags' => $tags->values()->all(),
         ]);
         $this->trigger(self::EVENT_BEFORE_PURGE, $event);
+
+        if ($isWebResponse) {
+            $response->getHeaders()->remove(HeaderEnum::CACHE_PURGE_TAG->value);
+        }
+
         $overflowTag = $this->overflowTag();
         $tags = $event->isValid
             ? $this->normalizeCacheTags(...$event->tags)

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -58,7 +58,6 @@ class StaticCache extends \yii\base\Component
     private ?int $cacheDuration = null;
     private Collection $tags;
     private Collection $tagsToPurge;
-    private Collection $elementsToPurge;
     private Collection $fetchUrls;
     private bool $collectingCacheInfo = false;
 
@@ -66,7 +65,6 @@ class StaticCache extends \yii\base\Component
     {
         $this->tags = Collection::make();
         $this->tagsToPurge = Collection::make();
-        $this->elementsToPurge = Collection::make();
         $this->fetchUrls = Collection::make();
     }
 
@@ -119,7 +117,6 @@ class StaticCache extends \yii\base\Component
                 try {
                     $this->sendPurgeTagsRequest(
                         $this->tagsToPurge,
-                        $this->elementsToPurge,
                         $this->fetchUrls,
                     );
                 } catch (\Throwable $e) {
@@ -194,7 +191,7 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        $this->addPurgeTags($tags->all(), $element);
+        $this->addPurgeTags($tags->all());
     }
 
     private function handleRegisterCacheOptions(RegisterCacheOptionsEvent $event): void
@@ -268,7 +265,7 @@ class StaticCache extends \yii\base\Component
 
         $environmentId = Module::getInstance()->getConfig()->environmentId;
         $tag = StaticCacheTag::create("$environmentId:uri:$uri");
-        $this->addPurgeTags([$tag], $element);
+        $this->addPurgeTags([$tag]);
         return true;
     }
 
@@ -301,19 +298,13 @@ class StaticCache extends \yii\base\Component
     /**
      * @param array<array-key, string|StaticCacheTag> $tags
      */
-    public function addPurgeTags(array $tags, ?ElementInterface $element = null): void
+    public function addPurgeTags(array $tags): void
     {
-        $tags = $this->normalizeCacheTags(...$tags);
-        $this->tagsToPurge->push(...$tags);
-
-        if ($element && $tags->isNotEmpty()) {
-            $this->elementsToPurge->push($element);
-        }
+        $this->tagsToPurge->push(...$this->normalizeCacheTags(...$tags));
     }
 
     private function sendPurgeTagsRequest(
         Collection $tags,
-        ?Collection $elements = null,
         ?Collection $fetchUrls = null,
     ): void {
         $response = Craft::$app->getResponse();
@@ -333,10 +324,6 @@ class StaticCache extends \yii\base\Component
 
         $event = new PurgeEvent([
             'tags' => $tags->values()->all(),
-            'elements' => ($elements ?? Collection::make())
-                ->unique(fn(ElementInterface $element) => spl_object_id($element))
-                ->values()
-                ->all(),
         ]);
         $this->trigger(self::EVENT_BEFORE_PURGE, $event);
         $overflowTag = $this->overflowTag();

--- a/src/events/PurgeEvent.php
+++ b/src/events/PurgeEvent.php
@@ -2,7 +2,6 @@
 
 namespace craft\cloud\events;
 
-use craft\base\ElementInterface;
 use craft\cloud\StaticCacheTag;
 use craft\events\CancelableEvent;
 
@@ -12,9 +11,4 @@ class PurgeEvent extends CancelableEvent
      * @var StaticCacheTag[] The static cache tags being purged.
      */
     public array $tags = [];
-
-    /**
-     * @var ElementInterface[] The elements that caused the purge.
-     */
-    public array $elements = [];
 }

--- a/src/events/PurgeEvent.php
+++ b/src/events/PurgeEvent.php
@@ -14,7 +14,7 @@ class PurgeEvent extends CancelableEvent
     public array $tags = [];
 
     /**
-     * @var ElementInterface|null The element that caused the purge, if any.
+     * @var ElementInterface[] The elements that caused the purge.
      */
-    public ?ElementInterface $element = null;
+    public array $elements = [];
 }

--- a/src/events/PurgeEvent.php
+++ b/src/events/PurgeEvent.php
@@ -8,7 +8,7 @@ use craft\events\CancelableEvent;
 class PurgeEvent extends CancelableEvent
 {
     /**
-     * @var StaticCacheTag[] The static cache tags being purged.
+     * @var array<array-key, string|StaticCacheTag> The static cache tags being purged.
      */
     public array $tags = [];
 }

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -8,7 +8,6 @@ use Aws\S3\S3Client;
 use Craft;
 use craft\behaviors\EnvAttributeParserBehavior;
 use craft\cloud\Module;
-use craft\cloud\StaticCache;
 use craft\cloud\StaticCacheTag;
 use craft\elements\Asset;
 use craft\errors\FsException;
@@ -206,9 +205,7 @@ abstract class Fs extends FlysystemFs
             $objectKey = $this->createBucketPath($path)->toString();
             $cdnTag = StaticCacheTag::create("$environmentId:cdn:$objectKey");
 
-            Module::getInstance()->getStaticCache()->purgeTags(
-                strlen($cdnTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH ? "$environmentId:overflow" : $cdnTag,
-            );
+            Module::getInstance()->getStaticCache()->addPurgeTags($cdnTag);
 
             return true;
         } catch (\Throwable $e) {

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -205,7 +205,7 @@ abstract class Fs extends FlysystemFs
             $objectKey = $this->createBucketPath($path)->toString();
             $cdnTag = StaticCacheTag::create("$environmentId:cdn:$objectKey");
 
-            Module::getInstance()->getStaticCache()->addPurgeTags($cdnTag);
+            Module::getInstance()->getStaticCache()->addPurgeTags([$cdnTag]);
 
             return true;
         } catch (\Throwable $e) {

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -424,8 +424,6 @@ class StaticCacheTest extends Unit
         $this->saveElement($staticCache, $element);
         $this->sendPendingPurgeTags($staticCache);
 
-        $this->assertTrue($this->collectionProperty($staticCache, 'tagsToPurge')->isEmpty());
-        $this->assertTrue($this->collectionProperty($staticCache, 'fetchUrls')->isEmpty());
         $this->assertNull($this->gatewayRequest);
     }
 
@@ -492,6 +490,31 @@ class StaticCacheTest extends Unit
             '123-environment-id:uri',
             '123-environment-id:cdn',
         ], $eventTags);
+    }
+
+    public function testPurgeTagsDoesNotSendCollectedBatch(): void
+    {
+        $staticCache = new StaticCache();
+        $element = new Entry(['uri' => 'news']);
+        $purgeElements = null;
+        $staticCache->on(StaticCache::EVENT_BEFORE_PURGE, function(PurgeEvent $event) use (&$purgeElements) {
+            $purgeElements = $event->elements;
+        });
+
+        $this->saveElement($staticCache, $element);
+        $staticCache->purgeTags('immediate');
+
+        $this->assertSame([], $purgeElements);
+        $this->assertSame(
+            'immediate',
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
+        );
+        $this->assertSame(
+            ['123-environment-id:uri:/news'],
+            $this->collectionProperty($staticCache, 'tagsToPurge')
+                ->map(fn(StaticCacheTag $tag) => $tag->getValue())
+                ->all(),
+        );
     }
 
     public function testExistingCacheTagHeaderIsSplit(): void
@@ -563,7 +586,12 @@ class StaticCacheTest extends Unit
     {
         $method = new ReflectionMethod($staticCache, 'sendPurgeTagsRequest');
         $method->setAccessible(true);
-        $method->invoke($staticCache);
+        $method->invoke(
+            $staticCache,
+            $this->collectionProperty($staticCache, 'tagsToPurge'),
+            $this->collectionProperty($staticCache, 'elementsToPurge'),
+            $this->collectionProperty($staticCache, 'fetchUrls'),
+        );
     }
 
     private function collectionProperty(StaticCache $staticCache, string $name): Collection

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -354,31 +354,6 @@ class StaticCacheTest extends Unit
         );
     }
 
-    public function testBeforePurgeEventReceivesElements(): void
-    {
-        $staticCache = new StaticCache();
-        $news = new Entry(['uri' => 'news']);
-        $about = new Entry(['uri' => 'about']);
-        $purgeEvent = null;
-        $staticCache->on(StaticCache::EVENT_BEFORE_PURGE, function(PurgeEvent $event) use (&$purgeEvent) {
-            $purgeEvent = $event;
-        });
-
-        $this->saveElement($staticCache, $news);
-        $this->saveElement($staticCache, $about);
-        $this->assertNull($purgeEvent);
-        $this->sendPendingPurgeTags($staticCache);
-
-        $this->assertSame([$news, $about], $purgeEvent->elements);
-        $this->assertSame(
-            [
-                '123-environment-id:uri:/news',
-                '123-environment-id:uri:/about',
-            ],
-            array_map(fn(StaticCacheTag $tag) => $tag->getValue(), $purgeEvent->tags),
-        );
-    }
-
     public function testHomepagePurgeUsesUriTag(): void
     {
         $staticCache = new StaticCache();
@@ -495,22 +470,16 @@ class StaticCacheTest extends Unit
     public function testPurgeTagsDoesNotSendCollectedBatch(): void
     {
         $staticCache = new StaticCache();
-        $element = new Entry(['uri' => 'news']);
-        $purgeElements = null;
-        $staticCache->on(StaticCache::EVENT_BEFORE_PURGE, function(PurgeEvent $event) use (&$purgeElements) {
-            $purgeElements = $event->elements;
-        });
 
-        $this->saveElement($staticCache, $element);
+        $staticCache->addPurgeTags(['collected']);
         $staticCache->purgeTags('immediate');
 
-        $this->assertSame([], $purgeElements);
         $this->assertSame(
             'immediate',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
         );
         $this->assertSame(
-            ['123-environment-id:uri:/news'],
+            ['collected'],
             $this->collectionProperty($staticCache, 'tagsToPurge')
                 ->map(fn(StaticCacheTag $tag) => $tag->getValue())
                 ->all(),
@@ -589,7 +558,6 @@ class StaticCacheTest extends Unit
         $method->invoke(
             $staticCache,
             $this->collectionProperty($staticCache, 'tagsToPurge'),
-            $this->collectionProperty($staticCache, 'elementsToPurge'),
             $this->collectionProperty($staticCache, 'fetchUrls'),
         );
     }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -339,6 +339,25 @@ class StaticCacheTest extends Unit
         );
     }
 
+    public function testBeforePurgeEventExceptionPreservesExistingHeaderTags(): void
+    {
+        $staticCache = new StaticCache();
+        Craft::$app->getResponse()->getHeaders()->set(HeaderEnum::CACHE_PURGE_TAG->value, 'first');
+        $staticCache->on(StaticCache::EVENT_BEFORE_PURGE, function() {
+            throw new \RuntimeException();
+        });
+
+        try {
+            $staticCache->purgeTags('second');
+        } catch (\RuntimeException) {
+        }
+
+        $this->assertSame(
+            'first',
+            Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
+        );
+    }
+
     public function testBeforePurgeEventCanReplaceTags(): void
     {
         $staticCache = new StaticCache();

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -242,6 +242,12 @@ class StaticCacheTest extends Unit
         $method->setAccessible(true);
 
         $this->assertTrue($method->invoke($fs, 'image.jpg'));
+        $this->assertFalse(
+            Craft::$app->getResponse()->getHeaders()->has(HeaderEnum::CACHE_PURGE_TAG->value),
+        );
+
+        $this->sendPendingPurgeTags($staticCache);
+
         $this->assertSame(
             '123-environment-id:cdn:123-environment-id/assets/image.jpg',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
@@ -257,6 +263,8 @@ class StaticCacheTest extends Unit
         $method->setAccessible(true);
 
         $this->assertTrue($method->invoke($fs, str_repeat('x', 1024)));
+        $this->sendPendingPurgeTags($staticCache);
+
         $this->assertSame(
             '123-environment-id:overflow',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
@@ -346,20 +354,27 @@ class StaticCacheTest extends Unit
         );
     }
 
-    public function testBeforePurgeEventReceivesElement(): void
+    public function testBeforePurgeEventReceivesElements(): void
     {
         $staticCache = new StaticCache();
-        $element = new Entry(['uri' => 'news']);
+        $news = new Entry(['uri' => 'news']);
+        $about = new Entry(['uri' => 'about']);
         $purgeEvent = null;
         $staticCache->on(StaticCache::EVENT_BEFORE_PURGE, function(PurgeEvent $event) use (&$purgeEvent) {
             $purgeEvent = $event;
         });
 
-        $this->saveElement($staticCache, $element);
+        $this->saveElement($staticCache, $news);
+        $this->saveElement($staticCache, $about);
+        $this->assertNull($purgeEvent);
+        $this->sendPendingPurgeTags($staticCache);
 
-        $this->assertSame($element, $purgeEvent->element);
+        $this->assertSame([$news, $about], $purgeEvent->elements);
         $this->assertSame(
-            ['123-environment-id:uri:/news'],
+            [
+                '123-environment-id:uri:/news',
+                '123-environment-id:uri:/about',
+            ],
             array_map(fn(StaticCacheTag $tag) => $tag->getValue(), $purgeEvent->tags),
         );
     }
@@ -397,7 +412,7 @@ class StaticCacheTest extends Unit
         $this->assertSame(['123-environment-id:overflow'], $payload['tags']);
     }
 
-    public function testCancelledElementPurgeDoesNotQueueFetch(): void
+    public function testCancelledElementPurgeDoesNotSendFetch(): void
     {
         $staticCache = new StaticCache();
         $element = new FetchableElement(['uri' => 'news']);
@@ -407,12 +422,14 @@ class StaticCacheTest extends Unit
         });
 
         $this->saveElement($staticCache, $element);
+        $this->sendPendingPurgeTags($staticCache);
 
         $this->assertTrue($this->collectionProperty($staticCache, 'tagsToPurge')->isEmpty());
         $this->assertTrue($this->collectionProperty($staticCache, 'fetchUrls')->isEmpty());
+        $this->assertNull($this->gatewayRequest);
     }
 
-    public function testDeletedElementPurgeDoesNotQueueFetch(): void
+    public function testDeletedElementPurgeDoesNotCollectFetch(): void
     {
         $staticCache = new StaticCache();
         $element = new FetchableElement(['uri' => 'news']);
@@ -427,10 +444,6 @@ class StaticCacheTest extends Unit
     public function testSavedElementPurgeRequestIncludesFetchUrls(): void
     {
         $staticCache = new StaticCache();
-        Craft::$app->getResponse()->getHeaders()->set(HeaderEnum::CACHE_PURGE_TAG->value, 'cancelled');
-        $staticCache->on(StaticCache::EVENT_BEFORE_PURGE, function(PurgeEvent $event) {
-            $event->isValid = $event->element !== null;
-        });
         $englishElement = new FetchableElement(['uri' => 'news']);
         $englishElement->fetchUrl = 'https://example.com/news';
         $frenchElement = clone $englishElement;
@@ -458,6 +471,27 @@ class StaticCacheTest extends Unit
         $this->assertFalse(
             Craft::$app->getResponse()->getHeaders()->has(HeaderEnum::CACHE_PURGE_TAG->value),
         );
+    }
+
+    public function testBeforePurgeEventFiresOnceForCollectedBatch(): void
+    {
+        $staticCache = new StaticCache();
+        $eventCount = 0;
+        $eventTags = [];
+        $staticCache->on(StaticCache::EVENT_BEFORE_PURGE, function(PurgeEvent $event) use (&$eventCount, &$eventTags) {
+            $eventCount++;
+            $eventTags = array_map(fn(StaticCacheTag $tag) => $tag->getValue(), $event->tags);
+        });
+
+        $staticCache->purgeAll();
+
+        $this->assertSame(0, $eventCount);
+        $this->sendPendingPurgeTags($staticCache);
+        $this->assertSame(1, $eventCount);
+        $this->assertSame([
+            '123-environment-id:uri',
+            '123-environment-id:cdn',
+        ], $eventTags);
     }
 
     public function testExistingCacheTagHeaderIsSplit(): void
@@ -527,13 +561,9 @@ class StaticCacheTest extends Unit
 
     private function sendPendingPurgeTags(StaticCache $staticCache): void
     {
-        $method = new ReflectionMethod($staticCache, 'sendTagPurgeRequest');
+        $method = new ReflectionMethod($staticCache, 'sendPurgeTagsRequest');
         $method->setAccessible(true);
-        $method->invoke(
-            $staticCache,
-            $this->collectionProperty($staticCache, 'tagsToPurge'),
-            $this->collectionProperty($staticCache, 'fetchUrls'),
-        );
+        $method->invoke($staticCache);
     }
 
     private function collectionProperty(StaticCache $staticCache, string $name): Collection


### PR DESCRIPTION
Collect static-cache purge tags until the request ends so file-heavy operations send a single gateway request instead of one request per file, while preserving explicit `purgeTags()` behavior. Fire the purge event once per send, defer overflow-tag handling until send time, and include saved-element fetch URLs when revalidation is needed.