### PR TITLE
Improve static cache purge diagnostics

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -64,7 +64,7 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
         $defaultContext = array_filter([
             'requestedRoute' => Craft::$app->requestedRoute,
             'requestedParams' => Craft::$app->requestedParams,
-            'url' => !$request->getIsConsoleRequest()
+            'url' => $request instanceof \craft\web\Request
                 ? $request->getAbsoluteUrl()
                 : null,
         ]);

--- a/src/Module.php
+++ b/src/Module.php
@@ -59,7 +59,20 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
 
     public static function log(int $level, string $message, array $context = []): void
     {
-        Craft::getLogger()->log(new PsrMessage($message, $context), $level, self::class);
+        $request = Craft::$app->getRequest();
+
+        $defaultContext = array_filter([
+            'requestedRoute' => Craft::$app->requestedRoute,
+            'requestedParams' => Craft::$app->requestedParams,
+            'url' => $request instanceof \craft\web\Request && !$request->getIsConsoleRequest()
+                ? $request->getAbsoluteUrl()
+                : null,
+        ]);
+
+        Craft::getLogger()->log(new PsrMessage(
+            $message,
+            $context + $defaultContext,
+        ), $level, self::class);
     }
 
     public static function info(string $message, array $context = []): void

--- a/src/Module.php
+++ b/src/Module.php
@@ -64,7 +64,7 @@ class Module extends \yii\base\Module implements \yii\base\BootstrapInterface
         $defaultContext = array_filter([
             'requestedRoute' => Craft::$app->requestedRoute,
             'requestedParams' => Craft::$app->requestedParams,
-            'url' => $request instanceof \craft\web\Request && !$request->getIsConsoleRequest()
+            'url' => !$request->getIsConsoleRequest()
                 ? $request->getAbsoluteUrl()
                 : null,
         ]);

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -124,6 +124,8 @@ class StaticCache extends \yii\base\Component
                         'Failed to purge tags after request',
                         [
                             'exception' => $e,
+                            'tags' => $this->tagsToPurge->all(),
+                            'fetchUrls' => $this->fetchUrls->unique()->values()->all(),
                         ],
                     );
                 }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -125,7 +125,7 @@ class StaticCache extends \yii\base\Component
                         [
                             'exception' => $e,
                             'tags' => $this->tagsToPurge->all(),
-                            'fetchUrls' => $this->fetchUrls->unique()->values()->all(),
+                            'fetchUrls' => $this->fetchUrls->all(),
                         ],
                     );
                 }

--- a/src/StaticCacheTag.php
+++ b/src/StaticCacheTag.php
@@ -20,12 +20,12 @@ class StaticCacheTag implements \Stringable, \JsonSerializable
         return new self($value);
     }
 
-    public function jsonSerialize(): false|string
+    public function jsonSerialize(): array
     {
-        return json_encode([
+        return [
             'value' => $this->getValue(),
             'originalValue' => $this->originalValue,
-        ]);
+        ];
     }
 
     public function __toString(): string

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -3,6 +3,7 @@
 use craft\test\TestSetup;
 
 ini_set('date.timezone', 'UTC');
+$_SERVER['REQUEST_URI'] = '/';
 
 define('CRAFT_ROOT_PATH', dirname(__DIR__));
 

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -3,7 +3,7 @@
 use craft\test\TestSetup;
 
 ini_set('date.timezone', 'UTC');
-$_SERVER['REQUEST_URI'] = '/';
+$_SERVER['REQUEST_URI'] ??= '/';
 
 define('CRAFT_ROOT_PATH', dirname(__DIR__));
 

--- a/tests/unit/ModuleTest.php
+++ b/tests/unit/ModuleTest.php
@@ -5,6 +5,7 @@ namespace craft\cloud\tests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\cloud\Module;
+use craft\web\Request;
 use samdark\log\PsrMessage;
 use yii\log\Logger;
 
@@ -13,15 +14,15 @@ class ModuleTest extends Unit
     public function testLogAddsRequestContext(): void
     {
         $originalLogger = Craft::getLogger();
+        $originalRequest = Craft::$app->getRequest();
         $logger = new Logger(['flushInterval' => 0]);
+        $request = new Request();
         $route = Craft::$app->requestedRoute;
         $params = Craft::$app->requestedParams;
-        $request = Craft::$app->getRequest();
-        $hostInfo = $request->getHostInfo();
-        $isConsoleRequest = $request->getIsConsoleRequest();
 
         try {
             Craft::setLogger($logger);
+            Craft::$app->set('request', $request);
             Craft::$app->requestedRoute = 'templates/render';
             Craft::$app->requestedParams = ['template' => 'news/_entry'];
             $request->setHostInfo('https://example.com');
@@ -32,11 +33,9 @@ class ModuleTest extends Unit
             $message = $logger->messages[array_key_last($logger->messages)][0];
         } finally {
             Craft::setLogger($originalLogger);
+            Craft::$app->set('request', $originalRequest);
             Craft::$app->requestedRoute = $route;
             Craft::$app->requestedParams = $params;
-            $request->setHostInfo($hostInfo);
-            $request->setUrl(null);
-            $request->setIsConsoleRequest($isConsoleRequest);
         }
 
         $this->assertInstanceOf(PsrMessage::class, $message);

--- a/tests/unit/ModuleTest.php
+++ b/tests/unit/ModuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace craft\cloud\tests\unit;
+
+use Codeception\Test\Unit;
+use Craft;
+use craft\cloud\Module;
+use samdark\log\PsrMessage;
+use yii\log\Logger;
+
+class ModuleTest extends Unit
+{
+    public function testLogAddsRequestContext(): void
+    {
+        $originalLogger = Craft::getLogger();
+        $logger = new Logger(['flushInterval' => 0]);
+        $route = Craft::$app->requestedRoute;
+        $params = Craft::$app->requestedParams;
+        $request = Craft::$app->getRequest();
+        $hostInfo = $request->getHostInfo();
+        $isConsoleRequest = $request->getIsConsoleRequest();
+
+        try {
+            Craft::setLogger($logger);
+            Craft::$app->requestedRoute = 'templates/render';
+            Craft::$app->requestedParams = ['template' => 'news/_entry'];
+            $request->setHostInfo('https://example.com');
+            $request->setUrl('/news/example?token=x&filter=recent');
+            $request->setIsConsoleRequest(false);
+
+            Module::info('Test', ['existing' => true]);
+            $message = $logger->messages[array_key_last($logger->messages)][0];
+        } finally {
+            Craft::setLogger($originalLogger);
+            Craft::$app->requestedRoute = $route;
+            Craft::$app->requestedParams = $params;
+            $request->setHostInfo($hostInfo);
+            $request->setUrl(null);
+            $request->setIsConsoleRequest($isConsoleRequest);
+        }
+
+        $this->assertInstanceOf(PsrMessage::class, $message);
+        $this->assertSame([
+            'existing' => true,
+            'requestedRoute' => 'templates/render',
+            'requestedParams' => ['template' => 'news/_entry'],
+            'url' => 'https://example.com/news/example?token=x&filter=recent',
+        ], $message->getContext());
+    }
+}

--- a/tests/unit/StaticCacheTagTest.php
+++ b/tests/unit/StaticCacheTagTest.php
@@ -61,4 +61,14 @@ class StaticCacheTagTest extends Unit
             StaticCacheTag::create('tag value')->minify(true)->getValue(),
         );
     }
+
+    public function testSerializesCurrentAndOriginalValues(): void
+    {
+        $tag = StaticCacheTag::create('tag value')->minify(true);
+
+        $this->assertSame([
+            'value' => $tag->getValue(),
+            'originalValue' => 'tag value',
+        ], $tag->jsonSerialize());
+    }
 }


### PR DESCRIPTION
Adds request context and the collected tags/fetch URLs to purge failure logs, while serializing cache tags with both normalized and original values. This should make customer-specific rate-limit failures traceable to the request and purge inputs.