### PR TITLE
fix(cache): invalidate rasterized asset output

### DIFF
--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -36,6 +36,8 @@ use yii\caching\TagDependency;
  *   - `cdn:{environmentId}:{objectKey}` (legacy; object key has no leading slash)
  *   - `{environmentId}:cdn`
  *   - `{environmentId}:cdn:{objectKey}` (object key has no leading slash)
+ *   - `{environmentId}:rasterize`
+ *   - `{environmentId}:rasterize:{objectKey}` (object key has no leading slash)
  * - Added by Craft:
  *   - `{environmentShortId}{hashed}`
  *   - `{environmentId}:overflow` (when the response has too many tags or a selector is too long)
@@ -250,7 +252,7 @@ class StaticCache extends \yii\base\Component
     public function purgeCdn(): void
     {
         $environmentId = Module::getInstance()->getConfig()->environmentId;
-        $this->addPurgeTags(["$environmentId:cdn"]);
+        $this->addPurgeTags(["$environmentId:cdn", "$environmentId:rasterize"]);
     }
 
     private function purgeElementUri(ElementInterface $element): bool

--- a/src/cli/controllers/StaticCacheController.php
+++ b/src/cli/controllers/StaticCacheController.php
@@ -17,6 +17,7 @@ class StaticCacheController extends Controller
             $module->getStaticCache()->purgeTags(
                 "$environmentId:uri",
                 "$environmentId:cdn",
+                "$environmentId:rasterize",
             );
         });
 
@@ -28,7 +29,10 @@ class StaticCacheController extends Controller
         $this->do('Purging CDN static cache', function() {
             $module = Module::getInstance();
             $environmentId = $this->environmentId();
-            $module->getStaticCache()->purgeTags("$environmentId:cdn");
+            $module->getStaticCache()->purgeTags(
+                "$environmentId:cdn",
+                "$environmentId:rasterize",
+            );
         });
 
         return ExitCode::OK;

--- a/src/fs/Fs.php
+++ b/src/fs/Fs.php
@@ -8,6 +8,7 @@ use Aws\S3\S3Client;
 use Craft;
 use craft\behaviors\EnvAttributeParserBehavior;
 use craft\cloud\Module;
+use craft\cloud\StaticCache;
 use craft\cloud\StaticCacheTag;
 use craft\elements\Asset;
 use craft\errors\FsException;
@@ -204,8 +205,16 @@ abstract class Fs extends FlysystemFs
             $environmentId = Module::getInstance()->getConfig()->environmentId;
             $objectKey = $this->createBucketPath($path)->toString();
             $cdnTag = StaticCacheTag::create("$environmentId:cdn:$objectKey");
+            $tags = [$cdnTag];
 
-            Module::getInstance()->getStaticCache()->addPurgeTags([$cdnTag]);
+            if ($this instanceof AssetsFs && in_array(strtolower(pathinfo($path, PATHINFO_EXTENSION)), ['pdf', 'svg'], true)) {
+                $rasterizeTag = StaticCacheTag::create("$environmentId:rasterize:$objectKey");
+                $tags[] = strlen($rasterizeTag->getValue()) > StaticCache::MAX_TAG_VALUE_LENGTH
+                    ? "$environmentId:rasterize"
+                    : $rasterizeTag;
+            }
+
+            Module::getInstance()->getStaticCache()->addPurgeTags($tags);
 
             return true;
         } catch (\Throwable $e) {

--- a/tests/unit/StaticCacheControllerTest.php
+++ b/tests/unit/StaticCacheControllerTest.php
@@ -42,9 +42,9 @@ class StaticCacheControllerTest extends Unit
         $controller->actionPurgeCdn();
 
         $this->assertSame([
-            ['123-environment-id:uri', '123-environment-id:cdn'],
+            ['123-environment-id:uri', '123-environment-id:cdn', '123-environment-id:rasterize'],
             ['123-environment-id:uri'],
-            ['123-environment-id:cdn'],
+            ['123-environment-id:cdn', '123-environment-id:rasterize'],
         ], $this->staticCache->purges);
     }
 

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -229,7 +229,7 @@ class StaticCacheTest extends Unit
         $staticCache->purgeAll();
 
         $this->assertSame(
-            ['123-environment-id:uri', '123-environment-id:cdn'],
+            ['123-environment-id:uri', '123-environment-id:cdn', '123-environment-id:rasterize'],
             $this->collectionProperty($staticCache, 'tagsToPurge')
                 ->map(fn(StaticCacheTag $tag) => $tag->getValue())
                 ->all(),
@@ -254,6 +254,43 @@ class StaticCacheTest extends Unit
         $this->assertSame(
             '123-environment-id:cdn:123-environment-id/assets/image.jpg',
             Craft::$app->getResponse()->getHeaders()->get(HeaderEnum::CACHE_PURGE_TAG->value),
+        );
+    }
+
+    public function testRasterizedAssetCdnPurgeUsesObjectTag(): void
+    {
+        $staticCache = new StaticCache();
+        Module::getInstance()->set('staticCache', $staticCache);
+        $fs = new AssetsFs();
+        $method = new ReflectionMethod($fs, 'invalidateCdnPath');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($fs, 'document.pdf'));
+        $this->assertTrue($method->invoke($fs, 'graphic.SVG'));
+
+        $this->assertSame([
+            '123-environment-id:cdn:123-environment-id/assets/document.pdf',
+            '123-environment-id:rasterize:123-environment-id/assets/document.pdf',
+            '123-environment-id:cdn:123-environment-id/assets/graphic.SVG',
+            '123-environment-id:rasterize:123-environment-id/assets/graphic.SVG',
+        ], $this->collectionProperty($staticCache, 'tagsToPurge')
+            ->map(fn(StaticCacheTag $tag) => $tag->getValue())
+            ->all());
+    }
+
+    public function testOverlongRasterizedAssetCdnPurgeUsesEnvironmentTag(): void
+    {
+        $staticCache = new StaticCache();
+        Module::getInstance()->set('staticCache', $staticCache);
+        $fs = new AssetsFs();
+        $method = new ReflectionMethod($fs, 'invalidateCdnPath');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($fs, str_repeat(' ', 340) . '.pdf'));
+
+        $this->assertSame(
+            '123-environment-id:rasterize',
+            $this->collectionProperty($staticCache, 'tagsToPurge')->last()->getValue(),
         );
     }
 
@@ -498,6 +535,7 @@ class StaticCacheTest extends Unit
         $this->assertSame([
             '123-environment-id:uri',
             '123-environment-id:cdn',
+            '123-environment-id:rasterize',
         ], $eventTags);
     }
 


### PR DESCRIPTION
PDF and SVG filesystem mutations now purge their object-specific rasterization cache tag alongside the CDN tag. Tags over Cloudflare’s 1,024-character limit fall back to the environment-wide rasterization tag, and full CDN clears now purge rasterized output as well. Other asset types retain their existing CDN-only invalidation.
