### PR TITLE
Notify Slack when Craft Cloud reviews are requested

### DIFF
--- a/.github/workflows/notify-craft-cloud-review.yml
+++ b/.github/workflows/notify-craft-cloud-review.yml
@@ -11,4 +11,4 @@ jobs:
     if: github.event.requested_team.slug == 'craft-cloud'
     uses: craftcms/.github/.github/workflows/pr-slack-notification.yml@v3
     secrets:
-      slack_webhook_url: ${{ secrets.CRAFT_CLOUD_SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_CLOUD_WEBHOOK_URL }}

--- a/.github/workflows/notify-craft-cloud-review.yml
+++ b/.github/workflows/notify-craft-cloud-review.yml
@@ -10,5 +10,4 @@ jobs:
   notify:
     if: github.event.requested_team.slug == 'craft-cloud'
     uses: craftcms/.github/.github/workflows/pr-slack-notification.yml@v3
-    secrets:
-      slack_webhook_url: ${{ secrets.SLACK_CLOUD_WEBHOOK_URL }}
+    secrets: inherit

--- a/.github/workflows/notify-craft-cloud-review.yml
+++ b/.github/workflows/notify-craft-cloud-review.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   notify:
-    uses: craftcms/.github/.github/workflows/notify-craft-cloud-review.yml@v3
+    if: github.event.requested_team.slug == 'craft-cloud'
+    uses: craftcms/.github/.github/workflows/pr-slack-notification.yml@v3
     secrets:
       slack_webhook_url: ${{ secrets.CRAFT_CLOUD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-craft-cloud-review.yml
+++ b/.github/workflows/notify-craft-cloud-review.yml
@@ -8,7 +8,6 @@ permissions: {}
 
 jobs:
   notify:
-    if: github.event.requested_team.slug == 'craft-cloud'
     uses: craftcms/.github/.github/workflows/notify-craft-cloud-review.yml@v3
     secrets:
       slack_webhook_url: ${{ secrets.CRAFT_CLOUD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-craft-cloud-review.yml
+++ b/.github/workflows/notify-craft-cloud-review.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   notify:
+    if: github.event.requested_team.slug == 'craft-cloud'
     uses: craftcms/.github/.github/workflows/notify-craft-cloud-review.yml@v3
     secrets:
       slack_webhook_url: ${{ secrets.CRAFT_CLOUD_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-craft-cloud-review.yml
+++ b/.github/workflows/notify-craft-cloud-review.yml
@@ -1,0 +1,13 @@
+name: Notify Craft Cloud review requests
+
+on:
+  pull_request_target:
+    types: [review_requested]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: craftcms/.github/.github/workflows/notify-craft-cloud-review.yml@v3
+    secrets:
+      slack_webhook_url: ${{ secrets.CRAFT_CLOUD_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Calls the shared PR Slack notification workflow when the Craft Cloud team is requested for review, posting to #craft-cloud. The caller passes organization secrets with secrets: inherit.

Depends on https://github.com/craftcms/.github/pull/106.