### PR TITLE
Require permissions before generating asset upload URLs

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -41,6 +41,9 @@ class AssetsController extends Controller
 
         if ($assetId) {
             $assetToReplace = Craft::$app->getAssets()->getAssetById($assetId);
+            if (!$assetToReplace) {
+                throw new NotFoundHttpException('Asset not found.');
+            }
             $folderId = $assetToReplace->folderId;
         }
 

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -39,7 +39,7 @@ class AssetsController extends Controller
         $folderId = $this->request->getBodyParam('folderId');
         $assetToReplace = null;
 
-        if ($assetId && !$folderId) {
+        if ($assetId) {
             $assetToReplace = Craft::$app->getAssets()->getAssetById($assetId);
             $folderId = $assetToReplace->folderId;
         }

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -37,9 +37,11 @@ class AssetsController extends Controller
         $fieldId = $this->request->getBodyParam('fieldId');
         $assetId = $this->request->getBodyParam('assetId');
         $folderId = $this->request->getBodyParam('folderId');
+        $assetToReplace = null;
 
         if ($assetId && !$folderId) {
-            $folderId = Craft::$app->getAssets()->getAssetById($assetId)->folderId;
+            $assetToReplace = Craft::$app->getAssets()->getAssetById($assetId);
+            $folderId = $assetToReplace->folderId;
         }
 
         if (!$folderId && !$fieldId) {
@@ -66,6 +68,13 @@ class AssetsController extends Controller
 
         if (!$folder) {
             throw new BadRequestHttpException('The target folder provided for uploading is not valid');
+        }
+
+        if ($assetToReplace) {
+            $this->requireVolumePermissionByAsset('replaceFiles', $assetToReplace);
+            $this->requirePeerVolumePermissionByAsset('replacePeerFiles', $assetToReplace);
+        } else {
+            $this->requireVolumePermissionByFolder('saveAssets', $folder);
         }
 
         $volume = $folder->getVolume();

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -17,6 +17,7 @@ use ReflectionMethod;
 use yii\base\Module as BaseModule;
 use yii\web\BadRequestHttpException;
 use yii\web\ForbiddenHttpException;
+use yii\web\NotFoundHttpException;
 
 class AssetsControllerTest extends Unit
 {
@@ -87,6 +88,31 @@ class AssetsControllerTest extends Unit
             ->willThrowException(new ForbiddenHttpException());
 
         $this->expectException(ForbiddenHttpException::class);
+
+        try {
+            $controller->actionGetUploadUrl();
+        } finally {
+            Craft::$app->set('assets', $assets);
+            $request->setBodyParams($bodyParams);
+        }
+    }
+
+    public function testGetUploadUrlRejectsUnknownReplacementAsset(): void
+    {
+        $assets = Craft::$app->getAssets();
+        $request = Craft::$app->getRequest();
+        $bodyParams = $request->getBodyParams();
+        $assetsMock = $this->createMock(AssetsService::class);
+        $assetsMock->expects($this->once())->method('getAssetById')->with(1)->willReturn(null);
+        Craft::$app->set('assets', $assetsMock);
+        $request->setBodyParams(['filename' => 'test.jpg', 'assetId' => 1]);
+
+        $controller = $this->getMockBuilder(AssetsController::class)
+            ->setConstructorArgs(['cloud-assets', Craft::$app])
+            ->onlyMethods(['requireAcceptsJson', 'requirePostRequest'])
+            ->getMock();
+
+        $this->expectException(NotFoundHttpException::class);
 
         try {
             $controller->actionGetUploadUrl();

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -11,9 +11,12 @@ use craft\cloud\fs\Fs;
 use craft\console\Controller as ConsoleController;
 use craft\elements\Asset;
 use craft\models\Volume;
+use craft\models\VolumeFolder;
+use craft\services\Assets as AssetsService;
 use ReflectionMethod;
 use yii\base\Module as BaseModule;
 use yii\web\BadRequestHttpException;
+use yii\web\ForbiddenHttpException;
 
 class AssetsControllerTest extends Unit
 {
@@ -21,6 +24,36 @@ class AssetsControllerTest extends Unit
      * @var \UnitTester
      */
     protected $tester;
+
+    public function testGetUploadUrlRequiresSaveAssetsPermission(): void
+    {
+        $assets = Craft::$app->getAssets();
+        $request = Craft::$app->getRequest();
+        $bodyParams = $request->getBodyParams();
+        $folder = new VolumeFolder(['id' => 1]);
+        $assetsMock = $this->createMock(AssetsService::class);
+        $assetsMock->method('findFolder')->willReturn($folder);
+        Craft::$app->set('assets', $assetsMock);
+        $request->setBodyParams(['filename' => 'test.jpg', 'folderId' => 1]);
+
+        $controller = $this->getMockBuilder(AssetsController::class)
+            ->setConstructorArgs(['cloud-assets', Craft::$app])
+            ->onlyMethods(['requireAcceptsJson', 'requirePostRequest', 'requireVolumePermissionByFolder'])
+            ->getMock();
+        $controller->expects($this->once())
+            ->method('requireVolumePermissionByFolder')
+            ->with('saveAssets', $folder)
+            ->willThrowException(new ForbiddenHttpException());
+
+        $this->expectException(ForbiddenHttpException::class);
+
+        try {
+            $controller->actionGetUploadUrl();
+        } finally {
+            Craft::$app->set('assets', $assets);
+            $request->setBodyParams($bodyParams);
+        }
+    }
 
     public function testVolumeSubpathReturnsEmptyStringOnCraft4(): void
     {

--- a/tests/unit/AssetsControllerTest.php
+++ b/tests/unit/AssetsControllerTest.php
@@ -55,6 +55,47 @@ class AssetsControllerTest extends Unit
         }
     }
 
+    public function testGetUploadUrlRequiresReplacementPermissions(): void
+    {
+        $assets = Craft::$app->getAssets();
+        $request = Craft::$app->getRequest();
+        $bodyParams = $request->getBodyParams();
+        $asset = new Asset();
+        $asset->folderId = 2;
+        $folder = new VolumeFolder(['id' => 2]);
+        $assetsMock = $this->createMock(AssetsService::class);
+        $assetsMock->expects($this->once())->method('getAssetById')->with(1)->willReturn($asset);
+        $assetsMock->expects($this->once())->method('findFolder')->with(['id' => 2])->willReturn($folder);
+        Craft::$app->set('assets', $assetsMock);
+        $request->setBodyParams(['filename' => 'test.jpg', 'assetId' => 1, 'folderId' => 1]);
+
+        $controller = $this->getMockBuilder(AssetsController::class)
+            ->setConstructorArgs(['cloud-assets', Craft::$app])
+            ->onlyMethods([
+                'requireAcceptsJson',
+                'requirePostRequest',
+                'requireVolumePermissionByAsset',
+                'requirePeerVolumePermissionByAsset',
+            ])
+            ->getMock();
+        $controller->expects($this->once())
+            ->method('requireVolumePermissionByAsset')
+            ->with('replaceFiles', $asset);
+        $controller->expects($this->once())
+            ->method('requirePeerVolumePermissionByAsset')
+            ->with('replacePeerFiles', $asset)
+            ->willThrowException(new ForbiddenHttpException());
+
+        $this->expectException(ForbiddenHttpException::class);
+
+        try {
+            $controller->actionGetUploadUrl();
+        } finally {
+            Craft::$app->set('assets', $assets);
+            $request->setBodyParams($bodyParams);
+        }
+    }
+
     public function testVolumeSubpathReturnsEmptyStringOnCraft4(): void
     {
         $volume = new Volume();


### PR DESCRIPTION
Require the appropriate volume permissions before generating presigned asset upload URLs. Resolve replacement uploads against the target asset folder, return not found for unknown targets, and add focused regression coverage.