### PR TITLE
Prevent stale GraphQL responses in the static cache

### DIFF
--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -141,6 +141,7 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
+        Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = false;
         Craft::$app->getElements()->startCollectingCacheInfo();
         $this->collectingCacheInfo = true;
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -174,6 +174,7 @@ class StaticCache extends \yii\base\Component
     private function handleBeforeExecuteGqlQuery(Event $event): void
     {
         if ($this->collectingCacheInfo) {
+            // TODO: Remove after https://github.com/craftcms/cms/pull/19505 reaches Cloud's minimum supported Craft version.
             Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = false;
         }
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -63,6 +63,7 @@ class StaticCache extends \yii\base\Component
     private Collection $tagsToPurge;
     private Collection $fetchUrls;
     private bool $collectingCacheInfo = false;
+    private ?bool $graphqlCaching = null;
 
     public function init(): void
     {
@@ -83,6 +84,12 @@ class StaticCache extends \yii\base\Component
             Gql::class,
             Gql::EVENT_BEFORE_EXECUTE_GQL_QUERY,
             fn(Event $event) => $this->handleBeforeExecuteGqlQuery($event),
+        );
+
+        Event::on(
+            Gql::class,
+            Gql::EVENT_AFTER_EXECUTE_GQL_QUERY,
+            fn(Event $event) => $this->handleAfterExecuteGqlQuery($event),
         );
 
         Event::on(
@@ -175,7 +182,17 @@ class StaticCache extends \yii\base\Component
     {
         if ($this->collectingCacheInfo) {
             // TODO: Remove after https://github.com/craftcms/cms/pull/19505 reaches Cloud's minimum supported Craft version.
-            Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = false;
+            $generalConfig = Craft::$app->getConfig()->getGeneral();
+            $this->graphqlCaching = $generalConfig->enableGraphqlCaching;
+            $generalConfig->enableGraphqlCaching = false;
+        }
+    }
+
+    private function handleAfterExecuteGqlQuery(Event $event): void
+    {
+        if ($this->graphqlCaching !== null) {
+            Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = $this->graphqlCaching;
+            $this->graphqlCaching = null;
         }
     }
 

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -12,6 +12,7 @@ use craft\events\TemplateEvent;
 use craft\helpers\ElementHelper;
 use craft\helpers\StringHelper;
 use craft\services\Elements;
+use craft\services\Gql;
 use craft\utilities\ClearCaches;
 use craft\web\UrlManager;
 use craft\web\View;
@@ -79,6 +80,16 @@ class StaticCache extends \yii\base\Component
         );
 
         Event::on(
+            Gql::class,
+            Gql::EVENT_BEFORE_EXECUTE_GQL_QUERY,
+            function() {
+                if ($this->collectingCacheInfo) {
+                    Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = false;
+                }
+            },
+        );
+
+        Event::on(
             View::class,
             View::EVENT_BEFORE_RENDER_PAGE_TEMPLATE,
             fn(TemplateEvent $event) => $this->handleBeforeRenderPageTemplate($event),
@@ -141,7 +152,6 @@ class StaticCache extends \yii\base\Component
             return;
         }
 
-        Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = false;
         Craft::$app->getElements()->startCollectingCacheInfo();
         $this->collectingCacheInfo = true;
     }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -181,7 +181,7 @@ class StaticCache extends \yii\base\Component
     private function handleBeforeExecuteGqlQuery(Event $event): void
     {
         if ($this->collectingCacheInfo) {
-            // TODO: Remove after https://github.com/craftcms/cms/pull/19505 reaches Cloud's minimum supported Craft version.
+            // TODO: Remove after https://github.com/craftcms/cms/pull/19508 reaches Cloud's minimum supported Craft version.
             $generalConfig = Craft::$app->getConfig()->getGeneral();
             $this->graphqlCaching = $generalConfig->enableGraphqlCaching;
             $generalConfig->enableGraphqlCaching = false;

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -82,11 +82,7 @@ class StaticCache extends \yii\base\Component
         Event::on(
             Gql::class,
             Gql::EVENT_BEFORE_EXECUTE_GQL_QUERY,
-            function() {
-                if ($this->collectingCacheInfo) {
-                    Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = false;
-                }
-            },
+            fn(Event $event) => $this->handleBeforeExecuteGqlQuery($event),
         );
 
         Event::on(
@@ -173,6 +169,13 @@ class StaticCache extends \yii\base\Component
         }
 
         $this->addCacheHeadersToWebResponse();
+    }
+
+    private function handleBeforeExecuteGqlQuery(Event $event): void
+    {
+        if ($this->collectingCacheInfo) {
+            Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = false;
+        }
     }
 
     private function handleBeforeRenderPageTemplate(TemplateEvent $event): void

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -125,7 +125,7 @@ class StaticCacheTest extends Unit
         $this->assertFalse($this->isCacheable($staticCache));
     }
 
-    public function testGraphqlCachingIsDisabledWhileCollectingCacheInfo(): void
+    public function testGraphqlCachingIsOnlyDisabledWhileCollectingCacheInfo(): void
     {
         $staticCache = new StaticCache();
         $generalConfig = Craft::$app->getConfig()->getGeneral();
@@ -140,6 +140,9 @@ class StaticCacheTest extends Unit
             $collectingCacheInfo->setValue($staticCache, true);
             $this->handleBeforeExecuteGqlQuery($staticCache);
             $this->assertFalse($generalConfig->enableGraphqlCaching);
+
+            $this->handleAfterExecuteGqlQuery($staticCache);
+            $this->assertTrue($generalConfig->enableGraphqlCaching);
         } finally {
             $generalConfig->enableGraphqlCaching = $enableGraphqlCaching;
         }
@@ -625,6 +628,12 @@ class StaticCacheTest extends Unit
     private function handleBeforeExecuteGqlQuery(StaticCache $staticCache): void
     {
         $method = new ReflectionMethod($staticCache, 'handleBeforeExecuteGqlQuery');
+        $method->invoke($staticCache, new \yii\base\Event());
+    }
+
+    private function handleAfterExecuteGqlQuery(StaticCache $staticCache): void
+    {
+        $method = new ReflectionMethod($staticCache, 'handleAfterExecuteGqlQuery');
         $method->invoke($staticCache, new \yii\base\Event());
     }
 

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -125,6 +125,26 @@ class StaticCacheTest extends Unit
         $this->assertFalse($this->isCacheable($staticCache));
     }
 
+    public function testGraphqlCachingIsDisabledWhileCollectingCacheInfo(): void
+    {
+        $staticCache = new StaticCache();
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+        $enableGraphqlCaching = $generalConfig->enableGraphqlCaching;
+
+        try {
+            $generalConfig->enableGraphqlCaching = true;
+            $this->handleBeforeExecuteGqlQuery($staticCache);
+            $this->assertTrue($generalConfig->enableGraphqlCaching);
+
+            $collectingCacheInfo = new ReflectionProperty($staticCache, 'collectingCacheInfo');
+            $collectingCacheInfo->setValue($staticCache, true);
+            $this->handleBeforeExecuteGqlQuery($staticCache);
+            $this->assertFalse($generalConfig->enableGraphqlCaching);
+        } finally {
+            $generalConfig->enableGraphqlCaching = $enableGraphqlCaching;
+        }
+    }
+
     public function testStaticCacheDirectivesPreferCdnCacheControl(): void
     {
         $staticCache = new StaticCache();
@@ -600,6 +620,12 @@ class StaticCacheTest extends Unit
         $method->setAccessible(true);
 
         return $method->invoke($staticCache);
+    }
+
+    private function handleBeforeExecuteGqlQuery(StaticCache $staticCache): void
+    {
+        $method = new ReflectionMethod($staticCache, 'handleBeforeExecuteGqlQuery');
+        $method->invoke($staticCache, new \yii\base\Event());
     }
 
     private function addCacheHeadersToWebResponse(StaticCache $staticCache): void


### PR DESCRIPTION
## Summary

GraphQL responses could be stored in the static cache without the element dependencies needed to invalidate them. Changes to queried elements would not purge those responses, leaving stale content cached until it expired.

Ensure statically cached GraphQL responses are invalidated when their queried elements change.