### PR TITLE
Restore GraphQL caching after query failures

### DIFF
--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -162,6 +162,11 @@ class StaticCache extends \yii\base\Component
 
     private function handleAfterPrepareWebResponse(Event $event): void
     {
+        if ($this->graphqlCachingStack !== []) {
+            Craft::$app->getConfig()->getGeneral()->enableGraphqlCaching = $this->graphqlCachingStack[0];
+            $this->graphqlCachingStack = [];
+        }
+
         if (!$this->isCacheable()) {
             return;
         }

--- a/tests/unit/StaticCacheTest.php
+++ b/tests/unit/StaticCacheTest.php
@@ -129,7 +129,9 @@ class StaticCacheTest extends Unit
     {
         $staticCache = new StaticCache();
         $generalConfig = Craft::$app->getConfig()->getGeneral();
+        $response = Craft::$app->getResponse();
         $enableGraphqlCaching = $generalConfig->enableGraphqlCaching;
+        $statusCode = $response->getStatusCode();
 
         try {
             $generalConfig->enableGraphqlCaching = true;
@@ -149,8 +151,20 @@ class StaticCacheTest extends Unit
 
             $this->handleAfterExecuteGqlQuery($staticCache);
             $this->assertTrue($generalConfig->enableGraphqlCaching);
+
+            $this->handleBeforeExecuteGqlQuery($staticCache);
+            $this->handleBeforeExecuteGqlQuery($staticCache);
+            $this->assertFalse($generalConfig->enableGraphqlCaching);
+
+            $response->setStatusCode(500);
+            $this->handleAfterPrepareWebResponse($staticCache);
+            $this->assertTrue($generalConfig->enableGraphqlCaching);
+
+            $graphqlCachingStack = new ReflectionProperty($staticCache, 'graphqlCachingStack');
+            $this->assertSame([], $graphqlCachingStack->getValue($staticCache));
         } finally {
             $generalConfig->enableGraphqlCaching = $enableGraphqlCaching;
+            $response->setStatusCode($statusCode);
         }
     }
 
@@ -640,6 +654,12 @@ class StaticCacheTest extends Unit
     private function handleAfterExecuteGqlQuery(StaticCache $staticCache): void
     {
         $method = new ReflectionMethod($staticCache, 'handleAfterExecuteGqlQuery');
+        $method->invoke($staticCache, new \yii\base\Event());
+    }
+
+    private function handleAfterPrepareWebResponse(StaticCache $staticCache): void
+    {
+        $method = new ReflectionMethod($staticCache, 'handleAfterPrepareWebResponse');
         $method->invoke($staticCache, new \yii\base\Event());
     }
 


### PR DESCRIPTION
An exception during GraphQL execution can skip the normal cleanup, leaving GraphQL result caching disabled for the rest of the request.

Ensure the request restores its original GraphQL caching setting even when execution fails.

Follow-up to #200 and https://github.com/craftcms/cloud/pull/200#discussion_r3882360249.